### PR TITLE
Upgrade to Akka 2.4.9-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ testOptions in Test += Tests.Argument("-oDF")
 // -a Show stack traces and exception class name for AssertionErrors.
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 
-val AkkaVersion = "2.4.8"
+val AkkaVersion = "2.4.9-RC1"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka"      %% "akka-stream"                         % AkkaVersion,


### PR DESCRIPTION
I also want to upgrade [akka-sse](https://github.com/hseeberger/akka-sse), but therefore this projects needs to be upgraded first because akka-sse depends on it.