### PR TITLE
Backpressure and multiple materialzation

### DIFF
--- a/amqp/build.sbt
+++ b/amqp/build.sbt
@@ -1,11 +1,11 @@
 lazy val amqp = (project in file(".")).
-  configs(IntegrationTest)
-  .enablePlugins(AutomateHeaderPlugin)
+  configs(IntegrationTest).
+  enablePlugins(AutomateHeaderPlugin)
 
 name := "akka-stream-contrib-amqp"
 
 libraryDependencies ++= Seq(
-  "com.rabbitmq"      %	 "amqp-client"           % "3.6.1" // APLv2
+  "com.rabbitmq" % "amqp-client" % "3.6.1" // APLv2
 )
 
 Defaults.itSettings

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,6 @@
 lazy val root = (project in file(".")).
   aggregate(contrib, mqtt)
 
-lazy val contrib = project.
-  enablePlugins(AutomateHeaderPlugin)
-
-lazy val mqtt = project.
-  enablePlugins(AutomateHeaderPlugin)
-
+lazy val contrib = project
+lazy val mqtt = project
 lazy val amqp = project

--- a/contrib/build.sbt
+++ b/contrib/build.sbt
@@ -1,7 +1,10 @@
+lazy val contrib = (project in file(".")).
+  enablePlugins(AutomateHeaderPlugin)
+
 name := "akka-stream-contrib"
 
 libraryDependencies ++= Seq(
-  "junit"                  %  "junit"                               % "4.12"        % "test", // Common Public License 1.0
-  "com.novocode"           %  "junit-interface"                     % "0.11"        % "test",  // BSD-like
-  "com.google.jimfs"       %  "jimfs"                               % "1.1"         % "test"  // ApacheV2
+  "junit"            %  "junit"           % "4.12" % Test, // Common Public License 1.0
+  "com.novocode"     %  "junit-interface" % "0.11" % Test, // BSD-like
+  "com.google.jimfs" %  "jimfs"           % "1.1"  % Test  // ApacheV2
 )

--- a/mqtt/build.sbt
+++ b/mqtt/build.sbt
@@ -1,3 +1,6 @@
+lazy val mqtt = (project in file(".")).
+  enablePlugins(AutomateHeaderPlugin)
+
 name := "akka-stream-contrib-mqtt"
 
 libraryDependencies ++= Seq(

--- a/mqtt/src/main/scala/MqttSource.scala
+++ b/mqtt/src/main/scala/MqttSource.scala
@@ -3,32 +3,34 @@
  */
 package akka.stream.contrib.mqtt
 
-import akka.NotUsed
+import akka.Done
 import akka.stream.scaladsl._
 import akka.stream.stage._
 import akka.stream._
-import scala.collection.mutable
-import scala.concurrent._
 import org.eclipse.paho.client.mqttv3.IMqttAsyncClient
 import org.eclipse.paho.client.mqttv3.IMqttToken
+import scala.collection.mutable
+import scala.concurrent._
 import scala.util.Try
+
+import java.util.concurrent.Semaphore
 
 object MqttSource {
 
   /**
    * Scala API:
    */
-  def apply(settings: MqttSourceSettings, bufferSize: Int): Source[MqttMessage, Future[NotUsed]] =
+  def apply(settings: MqttSourceSettings, bufferSize: Int): Source[MqttMessage, Future[Done]] =
     Source.fromGraph(new MqttSource(settings, bufferSize))
 
   /**
    * Java API:
    */
-  def create(settings: MqttSourceSettings, bufferSize: Int): akka.stream.javadsl.Source[MqttMessage, Future[NotUsed]] =
+  def create(settings: MqttSourceSettings, bufferSize: Int): akka.stream.javadsl.Source[MqttMessage, Future[Done]] =
     akka.stream.javadsl.Source.fromGraph(new MqttSource(settings, bufferSize))
 }
 
-final class MqttSource(settings: MqttSourceSettings, bufferSize: Int) extends GraphStageWithMaterializedValue[SourceShape[MqttMessage], Future[NotUsed]] {
+final class MqttSource(settings: MqttSourceSettings, bufferSize: Int) extends GraphStageWithMaterializedValue[SourceShape[MqttMessage], Future[Done]] {
 
   import MqttConnectorLogic._
 
@@ -36,20 +38,22 @@ final class MqttSource(settings: MqttSourceSettings, bufferSize: Int) extends Gr
   override val shape: SourceShape[MqttMessage] = SourceShape.of(out)
   override protected def initialAttributes: Attributes = Attributes.name("MqttSource")
 
-  private val subscriptionPromise = Promise[NotUsed]
+  private val subscriptionPromise = Promise[Done]
 
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = (new GraphStageLogic(shape) with MqttConnectorLogic {
 
     private val queue = mutable.Queue[MqttMessage]()
     private val mqttSubscriptionCallback: Try[IMqttToken] => Unit = conn =>
-      subscriptionPromise.complete(conn.map { _ => NotUsed })
+      subscriptionPromise.complete(conn.map { _ => Done })
+    private val backpressure = new Semaphore(bufferSize)
 
     override val connectionSettings = settings.connectionSettings
 
     setHandler(out, new OutHandler {
       override def onPull(): Unit = {
         if (queue.nonEmpty) {
-          pushAndAckMessage(queue.dequeue())
+          pushMessage(queue.dequeue())
+          backpressure.release()
         }
       }
     })
@@ -59,19 +63,20 @@ final class MqttSource(settings: MqttSourceSettings, bufferSize: Int) extends Gr
       client.subscribe(topics.toArray, qos.toArray, (), mqttSubscriptionCallback)
     }
 
+    override def beforeHandleMessage(): Unit = {
+      backpressure.acquire()
+    }
+
     override def handleMessage(message: MqttMessage): Unit = {
+      require(queue.size <= bufferSize)
       if (isAvailable(out)) {
-        pushAndAckMessage(message)
+        pushMessage(message)
       } else {
-        if (queue.size + 1 > bufferSize) {
-          failStage(new RuntimeException(s"Reached maximum buffer size $bufferSize"))
-        } else {
-          queue.enqueue(message)
-        }
+        queue.enqueue(message)
       }
     }
 
-    def pushAndAckMessage(message: MqttMessage): Unit = {
+    def pushMessage(message: MqttMessage): Unit = {
       push(out, message)
     }
 

--- a/mqtt/src/main/scala/MqttSource.scala
+++ b/mqtt/src/main/scala/MqttSource.scala
@@ -38,51 +38,54 @@ final class MqttSource(settings: MqttSourceSettings, bufferSize: Int) extends Gr
   override val shape: SourceShape[MqttMessage] = SourceShape.of(out)
   override protected def initialAttributes: Attributes = Attributes.name("MqttSource")
 
-  private val subscriptionPromise = Promise[Done]
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = {
 
-  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes) = (new GraphStageLogic(shape) with MqttConnectorLogic {
+    val subscriptionPromise = Promise[Done]
 
-    private val queue = mutable.Queue[MqttMessage]()
-    private val mqttSubscriptionCallback: Try[IMqttToken] => Unit = conn =>
-      subscriptionPromise.complete(conn.map { _ => Done })
-    private val backpressure = new Semaphore(bufferSize)
+    (new GraphStageLogic(shape) with MqttConnectorLogic {
 
-    override val connectionSettings = settings.connectionSettings
+      private val queue = mutable.Queue[MqttMessage]()
+      private val mqttSubscriptionCallback: Try[IMqttToken] => Unit = conn =>
+        subscriptionPromise.complete(conn.map { _ => Done })
+      private val backpressure = new Semaphore(bufferSize)
 
-    setHandler(out, new OutHandler {
-      override def onPull(): Unit = {
-        if (queue.nonEmpty) {
-          pushMessage(queue.dequeue())
-          backpressure.release()
+      override val connectionSettings = settings.connectionSettings
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit = {
+          if (queue.nonEmpty) {
+            pushMessage(queue.dequeue())
+            backpressure.release()
+          }
+        }
+      })
+
+      override def handleConnection(client: IMqttAsyncClient) = {
+        val (topics, qos) = settings.topics.unzip
+        client.subscribe(topics.toArray, qos.toArray, (), mqttSubscriptionCallback)
+      }
+
+      override def beforeHandleMessage(): Unit = {
+        backpressure.acquire()
+      }
+
+      override def handleMessage(message: MqttMessage): Unit = {
+        require(queue.size <= bufferSize)
+        if (isAvailable(out)) {
+          pushMessage(message)
+        } else {
+          queue.enqueue(message)
         }
       }
-    })
 
-    override def handleConnection(client: IMqttAsyncClient) = {
-      val (topics, qos) = settings.topics.unzip
-      client.subscribe(topics.toArray, qos.toArray, (), mqttSubscriptionCallback)
-    }
-
-    override def beforeHandleMessage(): Unit = {
-      backpressure.acquire()
-    }
-
-    override def handleMessage(message: MqttMessage): Unit = {
-      require(queue.size <= bufferSize)
-      if (isAvailable(out)) {
-        pushMessage(message)
-      } else {
-        queue.enqueue(message)
+      def pushMessage(message: MqttMessage): Unit = {
+        push(out, message)
       }
-    }
 
-    def pushMessage(message: MqttMessage): Unit = {
-      push(out, message)
-    }
+      override def handleConnectionLost(ex: Throwable) =
+        failStage(ex)
 
-    override def handleConnectionLost(ex: Throwable) =
-      failStage(ex)
-
-  }, subscriptionPromise.future)
+    }, subscriptionPromise.future)
+  }
 
 }


### PR DESCRIPTION
Add backpressure signalt to MQTT library by blocking library thread, when the internal buffer becomes full.

Also add support for multiple materialization by moving subscription future inside of create logic.