### PR TITLE
Add Cassandra Source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ cache:
 sudo: required
 services:
   - rabbitmq
+  - cassandra

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,12 @@
 lazy val root = (project in file(".")).
-  aggregate(contrib, mqtt, amqp, xmlparser).
+  aggregate(contrib, mqtt, amqp, xmlparser, cassandra).
   enablePlugins(GitVersioning)
 
 lazy val contrib = project
 lazy val mqtt = project
 lazy val amqp = project
 lazy val xmlparser = project
+lazy val cassandra = project
 
 git.useGitDescribe := true
 publishArtifact := false

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -1,0 +1,20 @@
+This project provides a way to transform a Cassandra's ResultSet into a Akka Stream's Source.
+
+Example:
+
+```scala
+import akka.actor.ActorSystem
+import akka.actor.stream.ActorMaterializer
+import akka.stream.contrib.cassandra.CassandraSource
+import com.datastax.driver.core.{SimpleStatement, Cluster}
+
+implicit val system = ActorSystem()
+implicit val mat = ActorMaterializer()
+
+val cluster = Cluster.builder.addContactPoint("127.0.0.1").withPort(9042).build
+implicit val session = cluster.connect()
+
+val stmt = new SimpleStatement("SELECT * FROM akka_stream_test.test")
+
+val cassSource: Source[Row, NotUsed] = CassandraSource(stmt)
+```

--- a/cassandra/build.sbt
+++ b/cassandra/build.sbt
@@ -1,0 +1,11 @@
+lazy val cassandra = (project in file(".")).
+  configs(IntegrationTest).
+  enablePlugins(AutomateHeaderPlugin)
+
+name := "akka-stream-contrib-cassandra"
+
+libraryDependencies ++= Seq(
+  "com.datastax.cassandra" % "cassandra-driver-core" % "3.1.0"
+)
+
+Defaults.itSettings

--- a/cassandra/src/main/scala/akka/stream/contrib/cassandra/CassandraSource.scala
+++ b/cassandra/src/main/scala/akka/stream/contrib/cassandra/CassandraSource.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib.cassandra
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream._
+import akka.stream.scaladsl.Source
+import akka.stream.stage.{ AsyncCallback, OutHandler, GraphStageLogic, GraphStage }
+import com.datastax.driver.core.{ ResultSet, Session, Statement, Row }
+import com.google.common.util.concurrent.{ ListenableFuture, FutureCallback, Futures }
+import scala.concurrent.{ Future, Promise }
+import scala.collection.JavaConverters._
+import scala.util.{ Try, Failure, Success }
+
+class CassandraSource(futStmt: Future[Statement], session: Session) extends GraphStage[SourceShape[Row]] {
+  val out: Outlet[Row] = Outlet("CassandraSource.out")
+  override val shape: SourceShape[Row] = SourceShape(out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) {
+      var maybeRs = Option.empty[ResultSet]
+      var futFetchedCallback: AsyncCallback[Try[ResultSet]] = _
+
+      override def preStart(): Unit = {
+        implicit val ec = materializer.executionContext
+
+        futFetchedCallback = getAsyncCallback[Try[ResultSet]](tryPushAfterFetch)
+
+        val futRs = futStmt.flatMap(stmt => guavaFutToScalaFut(session.executeAsync(stmt)))
+        futRs.onComplete(futFetchedCallback.invoke)
+      }
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit = {
+          implicit val ec = materializer.executionContext
+
+          maybeRs match {
+            case Some(rs) if rs.getAvailableWithoutFetching > 0 => push(out, rs.one())
+            case Some(rs) if rs.isExhausted                     => completeStage()
+            case Some(rs) =>
+              // fetch next page
+              val futRs = guavaFutToScalaFut(rs.fetchMoreResults())
+              futRs.onComplete(futFetchedCallback.invoke)
+            case None => () // doing nothing, waiting for futRs in preStart() to be completed
+          }
+        }
+      })
+
+      private def tryPushAfterFetch(rsOrFailure: Try[ResultSet]): Unit = rsOrFailure match {
+        case Success(rs) =>
+          maybeRs = Some(rs)
+          if (rs.getAvailableWithoutFetching > 0) {
+            if (isAvailable(out)) {
+              push(out, rs.one())
+            }
+          } else {
+            completeStage()
+          }
+
+        case Failure(failure) => failStage(failure)
+      }
+    }
+
+  private def guavaFutToScalaFut[A](guavaFut: ListenableFuture[A]): Future[A] = {
+    val p = Promise[A]()
+    val callback = new FutureCallback[A] {
+      override def onSuccess(a: A): Unit = p.success(a)
+      override def onFailure(err: Throwable): Unit = p.failure(err)
+    }
+    Futures.addCallback(guavaFut, callback)
+    p.future
+  }
+}
+
+object CassandraSource {
+  /**
+   * Scala API:
+   */
+  def apply(stmt: Statement)(implicit session: Session): Source[Row, NotUsed] =
+    Source.fromGraph(new CassandraSource(Future.successful(stmt), session))
+
+  def fromFuture(futStmt: Future[Statement])(implicit session: Session): Source[Row, NotUsed] =
+    Source.fromGraph(new CassandraSource(futStmt, session))
+
+  /**
+   * Java API:
+   */
+  def create(stmt: Statement, session: Session): akka.stream.javadsl.Source[Row, NotUsed] =
+    akka.stream.javadsl.Source.fromGraph(new CassandraSource(Future.successful(stmt), session))
+
+  def createFromFuture(
+    futStmt: java.util.concurrent.CompletableFuture[Statement],
+    session: Session
+  ): akka.stream.javadsl.Source[Row, NotUsed] = {
+    import scala.compat.java8.FutureConverters._
+    akka.stream.javadsl.Source.fromGraph(new CassandraSource(futStmt.toScala, session))
+  }
+}

--- a/cassandra/src/test/scala/akka/stream/contrib/cassandra/CassandraSourceSpec.scala
+++ b/cassandra/src/test/scala/akka/stream/contrib/cassandra/CassandraSourceSpec.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib.cassandra
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Sink, Source }
+import com.datastax.driver.core.{ SimpleStatement, Cluster }
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+import scala.concurrent._
+import scala.concurrent.duration._
+
+class CassandraSourceSpec extends WordSpec with ScalaFutures with BeforeAndAfterEach with BeforeAndAfterAll with MustMatchers {
+  implicit val system = ActorSystem()
+  implicit val mat = ActorMaterializer()
+
+  val cluster = Cluster.builder.addContactPoint("127.0.0.1").withPort(9042).build
+  implicit val session = cluster.connect()
+
+  override def beforeEach(): Unit = {
+    session.execute(
+      """
+        |CREATE KEYSPACE IF NOT EXISTS akka_stream_test WITH replication = {
+        |  'class': 'SimpleStrategy',
+        |  'replication_factor': '1'
+        |};
+      """.stripMargin
+    )
+    session.execute(
+      """
+        |CREATE TABLE IF NOT EXISTS akka_stream_test.test (
+        |    id int PRIMARY KEY
+        |);
+      """.stripMargin
+    )
+  }
+
+  override def afterEach(): Unit = {
+    session.execute("DROP TABLE IF EXISTS akka_stream_test.test;")
+    session.execute("DROP KEYSPACE IF EXISTS akka_stream_test;")
+  }
+
+  override def afterAll(): Unit = {
+    Await.result(system.terminate(), 5.seconds)
+  }
+
+  def populate() = {
+    (1 until 103).map { i =>
+      session.execute(s"INSERT INTO akka_stream_test.test(id) VALUES ($i)")
+      i
+    }
+  }
+
+  "CassandraSourceSpec" must {
+
+    "stream the result of a Cassandra statement with one page" in {
+      val data = populate()
+      val stmt = new SimpleStatement("SELECT * FROM akka_stream_test.test").setFetchSize(200)
+
+      val rows = CassandraSource(stmt)
+        .runWith(Sink.seq)
+        .futureValue
+
+      rows.map(_.getInt("id")) must contain theSameElementsAs data
+    }
+
+    "stream the result of a Cassandra statement with several pages" in {
+      val data = populate()
+      val stmt = new SimpleStatement("SELECT * FROM akka_stream_test.test").setFetchSize(20)
+
+      val rows = CassandraSource(stmt)
+        .runWith(Sink.seq)
+        .futureValue
+
+      rows.map(_.getInt("id")) must contain theSameElementsAs data
+    }
+
+    "support multiple materializations" in {
+      val data = populate()
+      val stmt = new SimpleStatement("SELECT * FROM akka_stream_test.test")
+
+      val source = CassandraSource(stmt)
+
+      source.runWith(Sink.seq).futureValue.map(_.getInt("id")) must contain theSameElementsAs data
+      source.runWith(Sink.seq).futureValue.map(_.getInt("id")) must contain theSameElementsAs data
+    }
+
+    "stream the result of Cassandra statement that results in no data" in {
+      val stmt = new SimpleStatement("SELECT * FROM akka_stream_test.test")
+
+      val rows = CassandraSource(stmt)
+        .runWith(Sink.seq)
+        .futureValue
+
+      rows mustBe empty
+    }
+
+  }
+
+}

--- a/cassandra/src/test/scala/akka/stream/contrib/cassandra/README.txt
+++ b/cassandra/src/test/scala/akka/stream/contrib/cassandra/README.txt
@@ -1,0 +1,1 @@
+All the tests must be run with a local Cassandra running on default port 9042.


### PR DESCRIPTION
This PR provides a way to transform a Cassandra's ResultSet into a Akka Stream's Source, i.e. it lets you stream the result of a Cassandra query.

Example:

```scala
import akka.actor.ActorSystem
import akka.actor.stream.ActorMaterializer
import akka.stream.contrib.cassandra.CassandraSource
import com.datastax.driver.core.{SimpleStatement, Cluster}

implicit val system = ActorSystem()
implicit val mat = ActorMaterializer()

val cluster = Cluster.builder.addContactPoint("127.0.0.1").withPort(9042).build
implicit val session = cluster.connect()

val stmt = new SimpleStatement("SELECT * FROM akka_stream_test.test")

val cassSource: Source[Row, NotUsed] = CassandraSource(stmt)
```