### PR TITLE
use Scala 2.11 as default

### DIFF
--- a/contrib/src/main/scala/akka/stream/contrib/Valve.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/Valve.scala
@@ -82,9 +82,9 @@ final class Valve[A](mode: SwitchMode) extends GraphStageWithMaterializedValue[F
               true
 
             case Close =>
-              if(isAvailable(in)) {
+              if (isAvailable(in)) {
                 push(out, grab(in))
-              }else if (isAvailable(out)) {
+              } else if (isAvailable(out)) {
                 pull(in)
               }
 

--- a/contrib/src/test/scala/akka/stream/contrib/ValveSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/ValveSpec.scala
@@ -6,8 +6,8 @@ package akka.stream.contrib
 import akka.actor.ActorSystem
 import akka.pattern.after
 import akka.stream.ActorMaterializer
-import akka.stream.contrib.SwitchMode.{Close, Open}
-import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.contrib.SwitchMode.{ Close, Open }
+import akka.stream.scaladsl.{ Keep, Sink, Source }
 import akka.stream.testkit.scaladsl._
 import org.scalatest._
 import org.scalatest.Matchers._
@@ -41,7 +41,7 @@ class ValveSpec extends WordSpec with ScalaFutures {
       }
 
       whenReady(seq, timeout(200 millis)) {
-        _ should contain inOrder(1, 2, 3)
+        _ should contain inOrder (1, 2, 3)
       }
     }
 
@@ -69,13 +69,11 @@ class ValveSpec extends WordSpec with ScalaFutures {
       probe.expectComplete()
     }
 
-
     "emit only 3 elements when the valve is switch to open/close/open" in {
       val ((sourceProbe, switch), sinkProbe) = TestSource.probe[Int]
         .viaMat(Valve())(Keep.both)
         .toMat(TestSink.probe[Int])(Keep.both)
         .run()
-
 
       sinkProbe.request(1)
       whenReady(switch.flip(Close)) {
@@ -128,7 +126,6 @@ class ValveSpec extends WordSpec with ScalaFutures {
         .viaMat(Valve(SwitchMode.Close))(Keep.right)
         .toMat(Sink.seq)(Keep.both)
         .run()
-
 
       whenReady(seq, timeout(200 millis)) {
         _ shouldBe empty
@@ -201,7 +198,7 @@ class ValveSpec extends WordSpec with ScalaFutures {
         .run()
 
       whenReady(seq, timeout(200 millis)) {
-        _ should contain inOrder(1, 2, 3)
+        _ should contain inOrder (1, 2, 3)
       }
     }
 
@@ -210,7 +207,6 @@ class ValveSpec extends WordSpec with ScalaFutures {
         .viaMat(Valve())(Keep.right)
         .toMat(Sink.seq)(Keep.both)
         .run()
-
 
       whenReady(seq, timeout(200 millis)) {
         _ shouldBe empty

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -22,9 +22,9 @@ object Common extends AutoPlugin {
 
     licenses := Seq(("Apache License, Version 2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
 
-    scalaVersion := "2.12.0",
     crossVersion := CrossVersion.binary,
-    crossScalaVersions := Vector(scalaVersion.value, "2.11.8"),
+    crossScalaVersions := Seq("2.11.8", "2.12.0"),
+    scalaVersion := crossScalaVersions.value.head,
 
     scalacOptions ++= Seq(
       "-encoding", "UTF-8",


### PR DESCRIPTION
* development should be done with Scala 2.11 so that new
  features (e.g. in library) are not accidentilly used