### PR TITLE
fix issue #86

### DIFF
--- a/contrib/src/main/resources/reference.conf
+++ b/contrib/src/main/resources/reference.conf
@@ -12,6 +12,7 @@ akka {
       # to get also the downstream cancelation (as graceful completion or failure which is propagated).
       # If inner flow fails to complete/fail downstream, stage is failed with an IllegalStateException.
       unfold-flow-timeout = 1m
+      retry-timeout = 5.seconds
     }
   }
 }


### PR DESCRIPTION
This pull request solves issue #86 
The suggested code of `RetryConcatCoordinator` now process more than 1 element at a given time.
It contains 2 queues which buffer elements for future emitting. 
In order to avoid finishing the stream too early (i.e., elements are still being processed within the stream but upstream signaled termination), a counter is maintained.