### PR TITLE
A potentially useful akka-stream stage for time-window processing

### DIFF
--- a/contrib/src/main/scala/akka/stream/contrib/Pulse.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/Pulse.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib
+
+import akka.stream.Attributes
+import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
+import akka.stream.stage._
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Signals demand only once every [[interval]] (''pulse'') and then back-pressures. Requested element is emitted downstream if there is demand.
+ *
+ * @param interval ''pulse'' period
+ * @param initiallyOpen if `true` - emits the first available element before ''pulsing''
+ * @tparam T type of element
+ */
+final class Pulse[T](val interval: FiniteDuration, val initiallyOpen: Boolean = false) extends SimpleLinearGraphStage[T] {
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+
+      setHandlers(in, out, this)
+
+      override def preStart(): Unit = if (!initiallyOpen) startPulsing()
+      override def onPush(): Unit = if (isAvailable(out)) push(out, grab(in))
+      override def onPull(): Unit = if (!pulsing) {
+        pull(in)
+        startPulsing()
+      }
+
+      override protected def onTimer(timerKey: Any): Unit = {
+        if (!isClosed(in) && !hasBeenPulled(in)) pull(in)
+      }
+
+      private def startPulsing() = {
+        pulsing = true
+        schedulePeriodically("PulseTimer", interval)
+      }
+      private var pulsing = false
+    }
+
+  override def toString = "Pulse"
+}

--- a/contrib/src/main/scala/akka/stream/contrib/Pulse.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/Pulse.scala
@@ -34,7 +34,7 @@ final class Pulse[T](val interval: FiniteDuration, val initiallyOpen: Boolean = 
       }
 
       override protected def onTimer(timerKey: Any): Unit = {
-        if (!isClosed(in) && !hasBeenPulled(in)) pull(in)
+        if (isAvailable(out) && !isClosed(in) && !hasBeenPulled(in)) pull(in)
       }
 
       private def startPulsing() = {

--- a/contrib/src/main/scala/akka/stream/contrib/Pulse.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/Pulse.scala
@@ -12,6 +12,10 @@ import scala.concurrent.duration.FiniteDuration
 /**
  * Signals demand only once every [[interval]] (''pulse'') and then back-pressures. Requested element is emitted downstream if there is demand.
  *
+ * It can be used to implement simple time-window processing
+ * where data is aggregated for predefined amount of time and the computed aggregate is emitted once per this time.
+ * See [[TimeWindow]]
+ *
  * @param interval ''pulse'' period
  * @param initiallyOpen if `true` - emits the first available element before ''pulsing''
  * @tparam T type of element

--- a/contrib/src/main/scala/akka/stream/contrib/TimeWindow.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/TimeWindow.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib
+
+import akka.NotUsed
+import akka.stream.scaladsl.Flow
+
+import scala.concurrent.duration.FiniteDuration
+
+object TimeWindow {
+  /**
+   * Aggregates data for predefined amount of time. The computed aggregate is emitted after window expires, thereafter a new window starts.
+   *
+   * For example:
+   * {{{
+   * Source.tick(0.seconds, 100.milliseconds, 1)
+   *    .via(TimeWindow(500.milliseconds, eager = false)(identity[Int])(_ + _))
+   * }}}
+   * will emit sum of 1s after each 500ms - so you could expect a stream of 5s if timers were ideal
+   * If ''eager'' had been true in the following example, you would have observed initial 1 with no delay, followed by stream of sums
+   *
+   * @param of window duration
+   * @param eager if ''true'' emits the very first seed with no delay, otherwise the first element emitted is the result of the first time-window aggregation
+   * @param seed provides the initial state when a new window starts
+   * @param aggregate produces updated aggregate
+   * @tparam A type of incoming element
+   * @tparam S type of outgoing (aggregated) element
+   * @return flow implementing time-window aggregation
+   */
+  def apply[A, S](of: FiniteDuration, eager: Boolean = true)(seed: A => S)(aggregate: (S, A) ⇒ S): Flow[A, S, NotUsed] =
+    Flow[A].conflateWithSeed(seed)(aggregate).via(new Pulse(of, eager))
+}

--- a/contrib/src/test/scala/akka/stream/contrib/PulseSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/PulseSpec.scala
@@ -14,7 +14,7 @@ class PulseSpecAutoFusingOff extends { val autoFusing = false } with PulseSpec
 class PulseSpecAutoFusingOn extends { val autoFusing = true } with PulseSpec
 
 trait PulseSpec extends BaseStreamSpec with ScalaFutures {
-  private val pulseInterval = 500.milliseconds
+  private val pulseInterval = 20.milliseconds
 
   "Pulse Stage" should {
 
@@ -36,16 +36,15 @@ trait PulseSpec extends BaseStreamSpec with ScalaFutures {
     }
 
     "keep backpressure if there is no demand from downstream" in {
-      val window = 10.millis
       val elements = 1 to 10
 
       val probe = Source(elements)
-        .via(new Pulse[Int](window.dilated))
+        .via(new Pulse[Int](pulseInterval.dilated))
         .runWith(TestSink.probe)
 
       probe.ensureSubscription()
       // lets waste some time without a demand and let pulse run its timer
-      probe.expectNoMsg(window * 10)
+      probe.expectNoMsg(pulseInterval * 10)
 
       probe.request(elements.length.toLong)
       elements.foreach(probe.expectNext)

--- a/contrib/src/test/scala/akka/stream/contrib/PulseSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/PulseSpec.scala
@@ -3,8 +3,8 @@
  */
 package akka.stream.contrib
 
-import akka.stream.scaladsl.{ Keep, Sink, Source }
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestDuration
 import org.scalatest.concurrent.ScalaFutures
 
@@ -43,11 +43,12 @@ trait PulseSpec extends BaseStreamSpec with ScalaFutures {
         .via(new Pulse[Int](window.dilated))
         .runWith(TestSink.probe)
 
-      probe.expectSubscription()
+      probe.ensureSubscription()
       // lets waste some time without a demand and let pulse run its timer
       probe.expectNoMsg(window * 10)
 
-      elements.foreach(probe.requestNext)
+      probe.request(elements.length.toLong)
+      elements.foreach(probe.expectNext)
     }
 
   }

--- a/contrib/src/test/scala/akka/stream/contrib/PulseSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/PulseSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib
+
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.testkit.scaladsl.TestSource
+import akka.testkit.TestDuration
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.duration._
+
+class PulseSpecAutoFusingOff extends { val autoFusing = false } with PulseSpec
+class PulseSpecAutoFusingOn extends { val autoFusing = true } with PulseSpec
+
+trait PulseSpec extends BaseStreamSpec with ScalaFutures {
+  private val pulseInterval = 500.milliseconds
+
+  "Pulse Stage" should {
+
+    "signal demand once every interval" in {
+      val (probe, future) = TestSource.probe[Int]
+        .via(new Pulse[Int](pulseInterval.dilated))
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+      probe.sendNext(1)
+      probe.expectNoMsg(pulseInterval)
+      probe.sendNext(2)
+      probe.expectNoMsg(pulseInterval)
+      probe.sendComplete()
+
+      whenReady(future) {
+        _ should contain inOrderOnly (1, 2)
+      }
+    }
+
+  }
+
+  "An initially-opened Pulse Stage" should {
+
+    "emit the first available element" in {
+      val future = Source.repeat(1)
+        .via(new Pulse[Int](pulseInterval.dilated, initiallyOpen = true))
+        .initialTimeout(2.milliseconds.dilated)
+        .runWith(Sink.headOption)
+
+      whenReady(future) {
+        _ shouldBe Some(1)
+      }
+    }
+
+    "signal demand once every interval" in {
+      val (probe, future) = TestSource.probe[Int]
+        .via(new Pulse[Int](pulseInterval.dilated, initiallyOpen = true))
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+      probe.sendNext(1)
+      probe.expectNoMsg(pulseInterval)
+      probe.sendNext(2)
+      probe.expectNoMsg(pulseInterval)
+      probe.sendComplete()
+
+      whenReady(future) {
+        _ should contain inOrderOnly (1, 2)
+      }
+    }
+
+  }
+}

--- a/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
@@ -35,13 +35,13 @@ trait TimeWindowSpec extends BaseStreamSpec with ScalaFutures {
       pub.sendNext(1)
       pub.sendNext(1)
       pub.sendNext(1)
-      sub.expectNext(timeWindow, 5)
+      sub.expectNext(timeWindow * 2, 5)
       pub.sendNext(1)
       pub.sendNext(1)
       pub.sendNext(1)
       pub.sendNext(1)
       pub.sendNext(1)
-      sub.expectNext(timeWindow, 5)
+      sub.expectNext(timeWindow * 2, 5)
     }
 
     "emit the first seed if eager" in {

--- a/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib
+
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.testkit.TestDuration
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.duration._
+
+/*
+conflateWithSeed seems not to work as expected because of buffering of each stage when auto-fusing=off
+class TimeWindowSpecAutoFusingOff extends { val autoFusing = false } with TimeWindowSpec
+ */
+class TimeWindowSpecAutoFusingOn extends { val autoFusing = true } with TimeWindowSpec
+
+trait TimeWindowSpec extends BaseStreamSpec with ScalaFutures {
+  private val timeWindow = 500.milliseconds
+
+  "TimeWindow flow" should {
+    "aggregate data for predefined amount of time" in {
+      val summingWindow = TimeWindow(timeWindow.dilated, eager = false)(identity[Int])(_ + _)
+
+      val (pub, sub) = TestSource.probe[Int]
+        .via(summingWindow)
+        .toMat(TestSink.probe)(Keep.both)
+        .run
+
+      sub.request(2)
+
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      sub.expectNext(timeWindow, 5)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      sub.expectNext(timeWindow, 5)
+    }
+
+    "emit the first seed if eager" in {
+      val summingWindow = TimeWindow(timeWindow.dilated, eager = true)(identity[Int])(_ + _)
+
+      val (pub, sub) = TestSource.probe[Int]
+        .via(summingWindow)
+        .toMat(TestSink.probe)(Keep.both)
+        .run
+
+      sub.request(2)
+
+      pub.sendNext(1)
+      sub.expectNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      pub.sendNext(1)
+      sub.expectNext(5)
+    }
+  }
+}

--- a/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
@@ -4,7 +4,7 @@
 package akka.stream.contrib
 
 import akka.stream.scaladsl.Keep
-import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
 import akka.testkit.TestDuration
 import org.scalatest.concurrent.ScalaFutures
 

--- a/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/TimeWindowSpec.scala
@@ -4,7 +4,7 @@
 package akka.stream.contrib
 
 import akka.stream.scaladsl.Keep
-import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.testkit.TestDuration
 import org.scalatest.concurrent.ScalaFutures
 
@@ -17,7 +17,7 @@ class TimeWindowSpecAutoFusingOff extends { val autoFusing = false } with TimeWi
 class TimeWindowSpecAutoFusingOn extends { val autoFusing = true } with TimeWindowSpec
 
 trait TimeWindowSpec extends BaseStreamSpec with ScalaFutures {
-  private val timeWindow = 500.milliseconds
+  private val timeWindow = 100.milliseconds
 
   "TimeWindow flow" should {
     "aggregate data for predefined amount of time" in {

--- a/contrib/src/test/scala/akka/stream/contrib/ValveSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/ValveSpec.scala
@@ -159,7 +159,6 @@ class ValveSpec extends WordSpec with ScalaFutures {
         r <- resultFuture
       } yield r
 
-
       whenReady(result) {
         _ shouldBe 1
       }
@@ -261,7 +260,6 @@ class ValveSpec extends WordSpec with ScalaFutures {
         _ = probe.sendComplete()
         r <- resultFuture
       } yield r
-
 
       whenReady(result) {
         _ shouldBe 1


### PR DESCRIPTION
Please refer to https://github.com/akka/akka/issues/22420 where motivation behind elements being committed was discussed. It was suggested there ( https://github.com/akka/akka/issues/22420#issuecomment-284156185 ) that a PR containing this work should go to contrib repository. At the cost of violating DRY, I am pasting relevant elements of the original issue here for easier reference:

> I couldn't find any existing stage to accomplish simple time-window processing where data is aggregated for predefined amount of time and the computed aggregate is emitted once per this time. While conflateWithSeed fits the "aggregation" part of processing very nicely, I couldn't find any element that could steer the back-pressure to pull the aggregate once in a while and push it downstream. delay is close, but since it needs at least one element input buffer, one ends up with situation where, conceptually: at t0 data is pulled from conflate stage and put into buffer to be emitted at t1, at t1 the next element is pulled (aggregate of ]t0, t1]) to be emitted at t2 and so on, which means unnecessary delay of at least one "window". groupedWithin might be used for this case, but it keeps elements in memory till time-window expires, which is unnecessary in my case, as all I care about is aggregated data which can be computed incrementally. Therefore I ended up writing a custom stage called Pulse which can be seen as backpressuring delay with no buffering.