### PR TITLE
Akka 2.5 support + custom timeout

### DIFF
--- a/contrib/src/main/scala/akka/stream/contrib/TestKit.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/TestKit.scala
@@ -5,10 +5,11 @@ package akka.stream.contrib
 
 import akka.actor.ActorRef
 import akka.actor.ActorRefWithCell
-import akka.stream.Materializer
+import akka.stream.{ ActorMaterializer, Materializer }
 import akka.stream.impl._
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
+
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
@@ -21,7 +22,7 @@ object TestKit {
 
   def assertAllStagesStopped[T](block: ⇒ T)(implicit materializer: Materializer): T =
     materializer match {
-      case impl: ActorMaterializerImpl ⇒
+      case impl: ActorMaterializer ⇒
         val probe = TestProbe()(impl.system)
         probe.send(impl.supervisor, StreamSupervisor.StopChildren)
         probe.expectMsg(StreamSupervisor.StoppedChildren)

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -11,7 +11,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 
 object Common extends AutoPlugin {
 
-  val AkkaVersion = "2.4.12"
+  val AkkaVersion = "2.5.0"
 
   override def trigger = allRequirements
   override def requires = plugins.JvmPlugin && HeaderPlugin

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
This change breaks Akka 2.4 compatibility. We need new `akka-stream-contrib` in order to run tests for `akka-stream-kafka` with Akka 2.5.0 support.