### PR TITLE
Dilate ScalaTest future timeout to 600ms (fixes #106)

### DIFF
--- a/contrib/build.sbt
+++ b/contrib/build.sbt
@@ -3,6 +3,11 @@ lazy val contrib = (project in file(".")).
 
 name := "akka-stream-contrib"
 
+// By default scalatest futures time out in 150 ms, dilate that to 600ms.
+// This should not impact the total test time as we don't expect to hit this
+// timeout, and indeed it doesn't appear to.
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-F", "4")
+
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream-testkit" % Common.AkkaVersion % "provided",
   "junit"             %  "junit"               % "4.12" % Test, // Common Public License 1.0

--- a/contrib/src/test/scala/akka/stream/contrib/ValveSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/ValveSpec.scala
@@ -33,17 +33,10 @@ class ValveSpec extends WordSpec with ScalaFutures {
 
       whenReady(switchFut) { switch =>
         after(100 millis, system.scheduler) {
-          val future: Future[Boolean] = switch.flip(Open)
-          whenReady(future, timeout(200 millis)) {
-            _ shouldBe true
-          }
+          switch.flip(Open)
+        }.futureValue shouldBe true
 
-          future
-        }
-
-        whenReady(seq, timeout(200 millis)) {
-          _ should contain inOrder (1, 2, 3)
-        }
+        seq.futureValue should contain inOrder (1, 2, 3)
       }
     }
 


### PR DESCRIPTION
Refs #106, #105 