### PR TITLE
converted tests to use flow from publisher & subscriber instead of killswitch

### DIFF
--- a/contrib/src/test/resources/application.conf
+++ b/contrib/src/test/resources/application.conf
@@ -1,7 +1,7 @@
 akka {
   stream {
     contrib {
-      # Setting timeout to wait only 100 millis instead of 1 minute for tests
+      # Setting timeout to wait only 300 millis instead of 1 minute for tests
       unfold-flow-timeout = 300ms
     }
   }

--- a/contrib/src/test/resources/application.conf
+++ b/contrib/src/test/resources/application.conf
@@ -1,0 +1,8 @@
+akka {
+  stream {
+    contrib {
+      # Setting timeout to wait only 100 millis instead of 1 minute for tests
+      unfold-flow-timeout = 300ms
+    }
+  }
+}


### PR DESCRIPTION
Tests are now deterministic, and not affected by race conditions.
Ref: #108 