### PR TITLE
Allow rate limiter to spill over (#125)

### DIFF
--- a/contrib/src/test/scala/akka/stream/contrib/IntervalBasedRateLimiterSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/IntervalBasedRateLimiterSpec.scala
@@ -127,7 +127,7 @@ trait IntervalBasedThrottlerTestKit extends BaseStreamSpec {
     }
 
     batches.flatten should contain theSameElementsInOrderAs (1 to numOfElements).inclusive
-    batches.size shouldBe (numOfElements / maxBatchSize)
+    batches.size should (be(numOfElements / maxBatchSize) or be(numOfElements / maxBatchSize + 1))
   }
 
   protected def infiniteSource: Source[Int, NotUsed] = Source(Stream.from(1, 1))


### PR DESCRIPTION
AFAICS we don't really promise to batch into exactly
`numOfElements / maxBatchSize` batches, but strictly
speaking just at least that. We see it spill over by
1 (4 instead of 3) batches for the 'frequency is very high' test.

Refs #125 