### PR TITLE
Add keep alive from buffer graph stage

### DIFF
--- a/contrib/src/main/scala/akka/stream/contrib/KeepAliveConcat.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/KeepAliveConcat.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib
+
+import akka.stream._
+import akka.stream.stage._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Sends elements from buffer if upstream does not emit for a configured amount of time. In other words, this
+ * stage attempts to maintains a base rate of emitted elements towards the downstream using elements from upstream.
+ *
+ * If upstream emits new elements until the accumulated elements in the buffer exceed the specified minimum size
+ * used as the keep alive elements, then the base rate is no longer maintained until we reach another period without
+ * elements form upstream.
+ *
+ * The keep alive period is the keep alive failover size times the interval.
+ *
+ * '''Emits when''' upstream emits an element or if the upstream was idle for the configured period
+ *
+ * '''Backpressures when''' downstream backpressures
+ *
+ * '''Completes when''' upstream completes
+ *
+ * '''Cancels when''' downstream cancels
+ *
+ * @see [[akka.stream.scaladsl.FlowOps#keepAlive]]
+ * @see [[akka.stream.scaladsl.FlowOps#expand]]
+ */
+final case class KeepAliveConcat[T](keepAliveFailoverSize: Int, interval: FiniteDuration, extrapolate: T ⇒ Seq[T])
+  extends GraphStage[FlowShape[T, T]] {
+
+  require(keepAliveFailoverSize > 0, "The buffer keep alive failover size must be greater than 0.")
+
+  val in = Inlet[T]("KeepAliveConcat.in")
+  val out = Outlet[T]("KeepAliveConcat.out")
+
+  override val shape = FlowShape(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new TimerGraphStageLogic(shape) with InHandler with OutHandler {
+
+      private val buffer = new java.util.ArrayDeque[T](keepAliveFailoverSize)
+
+      override def preStart(): Unit = {
+        schedulePeriodically(None, interval)
+        pull(in)
+      }
+
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        if (buffer.size() < keepAliveFailoverSize) buffer.addAll(extrapolate(elem).asJava)
+        else buffer.addLast(elem)
+
+        if (isAvailable(out) && !buffer.isEmpty) push(out, buffer.removeFirst())
+        else pull(in)
+      }
+
+      override def onPull(): Unit = {
+        if (isClosed(in)) {
+          if (buffer.isEmpty) completeStage()
+          else push(out, buffer.removeFirst())
+        } else if (buffer.size() > keepAliveFailoverSize) {
+          push(out, buffer.removeFirst())
+        } else if (!hasBeenPulled(in)) {
+          pull(in)
+        }
+      }
+
+      override def onTimer(timerKey: Any) = {
+        if (isAvailable(out) && !buffer.isEmpty) push(out, buffer.removeFirst())
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        if (buffer.isEmpty) completeStage()
+      }
+
+      setHandlers(in, out, this)
+    }
+}

--- a/contrib/src/test/scala/akka/stream/contrib/KeepAliveConcatSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/KeepAliveConcatSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+package akka.stream.contrib
+
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.testkit.{ TestPublisher, TestSubscriber }
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class KeepAliveConcatSpec extends BaseStreamSpec {
+
+  override protected def autoFusing = false
+
+  val settings = ActorMaterializerSettings(system)
+    .withInputBuffer(initialSize = 2, maxSize = 16)
+
+  implicit val materializer = ActorMaterializer(settings)
+
+  val sampleSource = Source((1 to 10).grouped(3).toVector)
+  val expand = (lst: IndexedSeq[Int]) ⇒ lst.toList.map(Vector(_))
+
+  "keepAliveConcat" must {
+
+    "not emit additional elements if upstream is fast enough" in {
+      Await.result(
+        sampleSource
+          .via(KeepAliveConcat(5, 1.second, expand))
+          .grouped(1000)
+          .runWith(Sink.head),
+        3.seconds
+      ).flatten should ===(1 to 10)
+    }
+
+    "emit elements periodically after silent periods" in {
+      val sourceWithIdleGap = Source((1 to 5).grouped(3).toList) ++
+        Source((6 to 10).grouped(3).toList).initialDelay(2.second)
+
+      Await.result(
+        sourceWithIdleGap
+          .via(KeepAliveConcat(5, 0.6.seconds, expand))
+          .grouped(1000)
+          .runWith(Sink.head),
+        3.seconds
+      ).flatten should ===(1 to 10)
+    }
+
+    "immediately pull upstream" in {
+      val upstream = TestPublisher.probe[Vector[Int]]()
+      val downstream = TestSubscriber.probe[Vector[Int]]()
+
+      Source.fromPublisher(upstream).via(KeepAliveConcat(2, 1.second, expand)).runWith(Sink.fromSubscriber(downstream))
+
+      downstream.request(1)
+
+      upstream.sendNext(Vector(1))
+      downstream.expectNext(Vector(1))
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "immediately pull upstream after busy period" in {
+      val upstream = TestPublisher.probe[IndexedSeq[Int]]()
+      val downstream = TestSubscriber.probe[IndexedSeq[Int]]()
+
+      (sampleSource ++ Source.fromPublisher(upstream))
+        .via(KeepAliveConcat(2, 1.second, expand))
+        .runWith(Sink.fromSubscriber(downstream))
+
+      downstream.request(10)
+      downstream.expectNextN((1 to 3).grouped(1).toVector ++ (4 to 10).grouped(3).toVector)
+
+      downstream.request(1)
+
+      upstream.sendNext(Vector(1))
+      downstream.expectNext(Vector(1))
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+    "work if timer fires before initial request after busy period" in {
+      val upstream = TestPublisher.probe[IndexedSeq[Int]]()
+      val downstream = TestSubscriber.probe[IndexedSeq[Int]]()
+
+      (sampleSource ++ Source.fromPublisher(upstream))
+        .via(KeepAliveConcat(2, 1.second, expand))
+        .runWith(Sink.fromSubscriber(downstream))
+
+      downstream.request(10)
+      downstream.expectNextN((1 to 3).grouped(1).toVector ++ (4 to 10).grouped(3).toVector)
+
+      downstream.expectNoMsg(1.5.second)
+      downstream.request(1)
+
+      upstream.sendComplete()
+      downstream.expectComplete()
+    }
+
+  }
+
+}
+


### PR DESCRIPTION
This stage helps when we want the keep alive functionality, but without injecting default elements (e.g. zeroes), and, instead, maintain a buffer and inject elements from it when the upstream is slow.

Example:
input elements: `[1,2,3]`
`keepAlive` (existing): `[1,2,0,0,3]` (no buffer, emit 0 to maitain the emit rate)
`keepAliveConcat` (this PR): `[1,2,3]` (2 and 3 were buffered and used to maintain the rate)

Initially, this PR was opened against the Akka project: https://github.com/akka/akka/pull/24658