### PR TITLE
Add by-name version of Source.repeat

### DIFF
--- a/contrib/src/main/scala/akka/stream/contrib/SourceRepeatEval.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/SourceRepeatEval.scala
@@ -6,36 +6,35 @@ package akka.stream.contrib
 
 import java.util.concurrent.atomic.AtomicBoolean
 import akka.actor.Cancellable
-import akka.stream.{Attributes, scaladsl}
+import akka.stream.{ Attributes, scaladsl }
 import akka.stream.impl.Unfold
 import akka.stream.scaladsl.Source
 
-
 /**
-  * Create a `Source` that will output elements of type `A`
-  * given a by-name "producer"
-  *
-  * Examples:
-  *
-  * stream of current times:
-  *
-  * {{{
-  *   SourceRepeatEval(System.currentTimeMillis)
-  * }}}
-  *
-  * stream of random numbers:
-  *
-  * {{{
-  *   SourceRepeatEval(Random.nextInt)
-  * }}}
-  *
-  * Behavior is the same as in
-  * {{{
-  *   Source.repeat(()).map(_ => x)
-  * }}}
-  *
-  * Supports cancellation via materialized `Cancellable`.
-  */
+ * Create a `Source` that will output elements of type `A`
+ * given a by-name "producer"
+ *
+ * Examples:
+ *
+ * stream of current times:
+ *
+ * {{{
+ *   SourceRepeatEval(System.currentTimeMillis)
+ * }}}
+ *
+ * stream of random numbers:
+ *
+ * {{{
+ *   SourceRepeatEval(Random.nextInt)
+ * }}}
+ *
+ * Behavior is the same as in
+ * {{{
+ *   Source.repeat(()).map(_ => x)
+ * }}}
+ *
+ * Supports cancellation via materialized `Cancellable`.
+ */
 object SourceRepeatEval {
   def apply[A](genElement: () => A): Source[A, Cancellable] = {
     val c: Cancellable = new Cancellable {

--- a/contrib/src/main/scala/akka/stream/contrib/SourceRepeatEval.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/SourceRepeatEval.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import java.util.concurrent.atomic.AtomicBoolean
+import akka.actor.Cancellable
+import akka.stream.Attributes
+import akka.stream.impl.Unfold
+import akka.stream.scaladsl.Source
+
+object SourceRepeatEval {
+  def apply[T](element: => T): Source[T, Cancellable] = {
+    val c: Cancellable = new Cancellable {
+      private val stopped: AtomicBoolean = new AtomicBoolean(false)
+      override def cancel(): Boolean = stopped.compareAndSet(false, true)
+      override def isCancelled: Boolean = stopped.get()
+    }
+
+    def nextElement(): T = element
+
+    def nextStep: Unit => Option[(Unit, T)] = {
+      _ =>
+        {
+          if (c.isCancelled) {
+            None
+          } else {
+            Some(() -> nextElement())
+          }
+        }
+    }
+
+    Source
+      .fromGraph(new Unfold[Unit, T]((), nextStep))
+      .withAttributes(Attributes.name("repeat-eval"))
+      .mapMaterializedValue(_ => c)
+  }
+}

--- a/contrib/src/main/scala/akka/stream/contrib/SourceRepeatEval.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/SourceRepeatEval.scala
@@ -6,26 +6,26 @@ package akka.stream.contrib
 
 import java.util.concurrent.atomic.AtomicBoolean
 import akka.actor.Cancellable
-import akka.stream.{ Attributes, scaladsl }
+import akka.stream.Attributes
 import akka.stream.impl.Unfold
 import akka.stream.scaladsl.Source
 
 /**
  * Create a `Source` that will output elements of type `A`
- * given a by-name "producer"
+ * given a "producer" function
  *
  * Examples:
  *
  * stream of current times:
  *
  * {{{
- *   SourceRepeatEval(System.currentTimeMillis)
+ *   SourceRepeatEval(() => System.currentTimeMillis)
  * }}}
  *
  * stream of random numbers:
  *
  * {{{
- *   SourceRepeatEval(Random.nextInt)
+ *   SourceRepeatEval(() => Random.nextInt)
  * }}}
  *
  * Behavior is the same as in

--- a/contrib/src/test/scala/akka/stream/contrib/SourceRepeatEvalSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/SourceRepeatEvalSpec.scala
@@ -41,5 +41,23 @@ class SourceRepeatEvalSpec extends BaseStreamSpec {
       probe.request(1)
       probe.expectComplete()
     }
+
+    "report correct cancellation state" in {
+      val int = new AtomicInteger(0)
+
+      val (c, probe) = SourceRepeatEval(() => int.getAndIncrement())
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      assert(probe.requestNext() == 0)
+      assert(!c.isCancelled)
+
+      assert(c.cancel())
+
+      probe.request(1).expectComplete()
+
+      assert(c.isCancelled)
+      assert(!c.cancel())
+    }
   }
 }

--- a/contrib/src/test/scala/akka/stream/contrib/SourceRepeatEvalSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/SourceRepeatEvalSpec.scala
@@ -16,7 +16,7 @@ class SourceRepeatEvalSpec extends BaseStreamSpec {
     "generate elements" in {
       val int = new AtomicInteger(0)
 
-      val probe = SourceRepeatEval(int.getAndIncrement())
+      val probe = SourceRepeatEval(() => int.getAndIncrement())
         .take(10)
         .toMat(TestSink.probe)(Keep.right)
         .run()
@@ -28,7 +28,7 @@ class SourceRepeatEvalSpec extends BaseStreamSpec {
     }
 
     "support cancellation" in {
-      val (c, probe) = SourceRepeatEval(Random.nextInt)
+      val (c, probe) = SourceRepeatEval(() => Random.nextInt)
         .toMat(TestSink.probe)(Keep.both)
         .run()
 

--- a/contrib/src/test/scala/akka/stream/contrib/SourceRepeatEvalSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/SourceRepeatEvalSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.util.Random
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.scaladsl.TestSink
+
+class SourceRepeatEvalSpec extends BaseStreamSpec {
+  override protected def autoFusing: Boolean = true
+
+  "SourceRepeatEval" should {
+    "generate elements" in {
+      val int = new AtomicInteger(0)
+
+      val probe = SourceRepeatEval(int.getAndIncrement())
+        .take(10)
+        .toMat(TestSink.probe)(Keep.right)
+        .run()
+
+      assert(
+        probe.request(10).expectNextN(10) == (0 until 10))
+
+      assert(int.get() == 10)
+    }
+
+    "support cancellation" in {
+      val (c, probe) = SourceRepeatEval(Random.nextInt)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      probe.requestNext()
+      probe.requestNext()
+      probe.requestNext()
+
+      c.cancel()
+
+      probe.request(1)
+      probe.expectComplete()
+    }
+  }
+}


### PR DESCRIPTION
People often need this and I think there is an advantage to having this as opposed to always doing

```scala
Source.repeat(()).map(_ => ...)
```