### PR TITLE
Add FeedbackLoop operator, a deadlock-free way of introducing cycles.

### DIFF
--- a/contrib/src/main/scala/akka/stream/contrib/FeedbackLoop.scala
+++ b/contrib/src/main/scala/akka/stream/contrib/FeedbackLoop.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import akka.stream.scaladsl.{ Flow, GraphDSL, Keep, MergePreferred }
+import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import akka.stream.{ Attributes, FanOutShape2, FlowShape, Graph, Inlet, Outlet, OverflowStrategy }
+
+object FeedbackLoop {
+
+  /**
+   * Feeds `forwardFlow`'s first output [[O0]] via `feedbackArc` back to `forwardFlow`'s input.
+   * To prevent deadlocks, `feedbackArc` is never backpressured. Instead, elements emitted by
+   * the `feedbackArc` are buffered and the resulting flow fails if that buffer overflows.
+   */
+  def apply[I, O0, O, M1, M2, M](
+    forwardFlow:        Graph[FanOutShape2[I, O0, O], M1],
+    feedbackArc:        Graph[FlowShape[O0, I], M2],
+    feedbackBufferSize: Int)(
+    combineMat: (M1, M2) => M): Flow[I, O, M] = Flow.fromGraph(GraphDSL.create(forwardFlow, feedbackArc)(combineMat) { implicit builder => (fw, fb) => {
+    import GraphDSL.Implicits._
+
+    val merge = builder.add(MergePreferred[I](1))
+    merge.out ~> fw.in
+
+    // Feed forwardFlow's first output to feedbackArc, but do not signal feedbackArc's cancellation to forwardFlow.
+    // Failure or completion will propagate to forwardFlow from the other end of the feedbackArc.
+    fb <~ ignoreAfterDownstreamFinish[O0] <~ fw.out0
+
+    // Feed feedbackArc back to forwardFlow, but never backpressure feedbackArc.
+    // To that end, use an intermediate buffer that fails on overflow.
+    merge.preferred <~ Flow[I].buffer(feedbackBufferSize, OverflowStrategy.fail) <~ fb
+
+    FlowShape(merge.in(0), fw.out1)
+  }
+  })
+
+  object Implicits {
+    implicit class FanOut2Ops[I, O0, O, M1](val fanOut: Graph[FanOutShape2[I, O0, O], M1]) extends AnyVal {
+      def feedbackViaMat[M2, M](feedbackArc: Graph[FlowShape[O0, I], M2], feedbackBufferSize: Int)(combineMat: (M1, M2) => M): Flow[I, O, M] =
+        FeedbackLoop(fanOut, feedbackArc, feedbackBufferSize)(combineMat)
+
+      def feedbackVia[M2](feedbackArc: Graph[FlowShape[O0, I], M2], feedbackBufferSize: Int): Flow[I, O, M1] =
+        feedbackViaMat(feedbackArc, feedbackBufferSize)(Keep.left)
+    }
+
+    implicit class FeedbackShapeOps[I, O, M](val fanOut: Graph[FanOutShape2[I, I, O], M]) extends AnyVal {
+      def feedback(feedbackBufferSize: Int): Flow[I, O, M] =
+        fanOut.feedbackVia(Flow[I], feedbackBufferSize)
+    }
+  }
+
+  /**
+   * Flow that passes all upstream elements downstream and after downstream completes,
+   * keeps consuming (and ignoring) all upstream elements.
+   */
+  private def ignoreAfterDownstreamFinish[T]: GraphStage[FlowShape[T, T]] =
+    new GraphStage[FlowShape[T, T]] {
+      override val shape: FlowShape[T, T] = FlowShape(Inlet("in"), Outlet("out"))
+
+      override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+        var downstreamFinished = false
+
+        setHandler(shape.out, new OutHandler {
+          override def onPull(): Unit = pull(shape.in)
+
+          override def onDownstreamFinish(): Unit = {
+            downstreamFinished = true
+            if (!hasBeenPulled(shape.in)) {
+              pull(shape.in)
+            }
+          }
+        })
+
+        setHandler(shape.in, new InHandler {
+          def onPush(): Unit = {
+            val elem = grab(shape.in)
+            if (downstreamFinished) {
+              pull(shape.in)
+            } else {
+              push(shape.out, elem)
+            }
+          }
+        })
+      }
+    }
+}

--- a/contrib/src/test/scala/akka/stream/contrib/FeedbackLoopSpec.scala
+++ b/contrib/src/test/scala/akka/stream/contrib/FeedbackLoopSpec.scala
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import akka.stream.{ Attributes, OverflowStrategy }
+import akka.stream.scaladsl.{ Flow, Keep, Source }
+import akka.stream.testkit.scaladsl.{ TestSink, TestSource }
+import scala.concurrent.duration._
+
+class FeedbackLoopSpecAutoFusingOn extends { val autoFusing = true } with FeedbackLoopSpec
+
+class FeedbackLoopSpecAutoFusingOff extends { val autoFusing = false } with FeedbackLoopSpec
+
+trait FeedbackLoopSpec extends BaseStreamSpec {
+
+  "Feedback" should {
+    "not deadlock on slow downstream" in {
+      val N = 1000
+
+      val forwardFlow = PartitionWith((i: Int) => if (i % 2 == 1) Left(i / 2) else Right(i))
+      val feedbackArc = Flow[Int]
+      val testedFlow = FeedbackLoop(forwardFlow, feedbackArc, N / 2)(Keep.none)
+
+      val sub = Source(1 to N)
+        .via(testedFlow)
+        .via(Flow[Int].delay(1.millis, OverflowStrategy.backpressure))
+        .toMat(TestSink.probe[Int])(Keep.right)
+        .run()
+
+      sub.request(n = N.toLong)
+      sub.expectNextN(N.toLong)
+    }
+
+    "not deadlock on slow feedback arc" in {
+      val bufferSize = 8
+
+      val forwardFlow = PartitionWith((i: Long) => if (i % 2 == 1) Left(i / 2) else Right(i))
+      val feedbackArc = Flow[Long]
+        .delay(1.millis, OverflowStrategy.backpressure)
+        .withAttributes(Attributes.inputBuffer(bufferSize, bufferSize))
+      val testedFlow = FeedbackLoop(forwardFlow, feedbackArc, bufferSize)(Keep.none)
+
+      val (pub, sub) = TestSource.probe[Long]
+        .via(testedFlow)
+        .toMat(TestSink.probe[Long])(Keep.both)
+        .run()
+
+      val N = 1000L
+
+      sub.request(n = N)
+      for (i <- 1L to N) {
+        pub.sendNext(i)
+      }
+
+      sub.expectNextN(N)
+    }
+
+    "fail on too many messages in the feedback arc" in {
+      val forwardFlow = PartitionWith((i: Long) => if (i > 0) Left(i - 1) else Right(i))
+      val feedbackArc = Flow[Long].mapConcat(i => List(i, i))
+      val testedFlow = FeedbackLoop(forwardFlow, feedbackArc, 1000)(Keep.none)
+
+      val (pub, sub) = TestSource.probe[Long]
+        .via(testedFlow)
+        .toMat(TestSink.probe[Long])(Keep.both)
+        .run()
+
+      sub.request(n = 1)
+      pub.sendNext(1000L)
+      sub.expectError()
+    }
+
+    "fail on forward flow failure" in {
+      import PartitionWith.Implicits._
+
+      val forwardFlow = Flow[Long]
+        .mapConcat(i => if (i > 0L) List(Left(i - 1), Right(i)) else throw new IllegalArgumentException(i.toString))
+        .partitionWith(identity)
+      val feedbackArc = Flow[Long]
+      val testedFlow = FeedbackLoop(forwardFlow, feedbackArc, 1)(Keep.none)
+
+      val (pub, sub) = TestSource.probe[Long]
+        .via(testedFlow)
+        .toMat(TestSink.probe[Long])(Keep.both)
+        .run()
+
+      sub.request(n = 10)
+      pub.sendNext(5L)
+      sub.expectNext(5L, 4L, 3L, 2L, 1L)
+      val error = sub.expectError()
+      assert(error.asInstanceOf[IllegalArgumentException].getMessage == 0L.toString)
+    }
+
+    "fail on feedback arc failure" in {
+      import PartitionWith.Implicits._
+
+      val forwardFlow = Flow[Long]
+        .mapConcat(i => if (i > 0L) List(Left(i - 1), Right(i)) else List(Right(i)))
+        .partitionWith(identity)
+      val feedbackArc = Flow[Long].map(i => if (i > 2L) i else throw new IllegalArgumentException(i.toString))
+      val testedFlow = FeedbackLoop(forwardFlow, feedbackArc, 1)(Keep.none)
+
+      val (pub, sub) = TestSource.probe[Long]
+        .via(testedFlow)
+        .toMat(TestSink.probe[Long])(Keep.both)
+        .run()
+
+      sub.request(n = 10)
+      pub.sendNext(5L)
+      sub.expectNext(5L, 4L, 3L)
+      val error = sub.expectError()
+      assert(error.asInstanceOf[IllegalArgumentException].getMessage == 2L.toString)
+    }
+
+    "fail on upstream failure" in {
+      import PartitionWith.Implicits._
+      import FeedbackLoop.Implicits._
+
+      val forwardFlow = Flow[Long]
+        .mapConcat(i => if (i > 0L) List(Left(i - 1), Right(i)) else List(Right(i)))
+        .partitionWith(identity)
+      val testedFlow = forwardFlow.feedback(1)
+
+      val (pub, sub) = TestSource.probe[Long]
+        .via(testedFlow)
+        .toMat(TestSink.probe[Long])(Keep.both)
+        .run()
+
+      sub.request(n = 10)
+      pub.sendNext(5L)
+      sub.expectNext(5L, 4L, 3L, 2L, 1L, 0L)
+      pub.sendError(new IllegalArgumentException("foo"))
+      val error = sub.expectError()
+      assert(error.asInstanceOf[IllegalArgumentException].getMessage == "foo")
+    }
+
+    "keep working after feedback arc completes" in {
+      import PartitionWith.Implicits._
+
+      val forwardFlow = Flow[Long]
+        .mapConcat { i => if (i > 0L) List(Left(i - 1), Right(i)) else List(Right(i)) }
+        .partitionWith(identity)
+      val feedbackArc = Flow[Long].take(5)
+      val testedFlow = FeedbackLoop(forwardFlow, feedbackArc, 1)(Keep.none)
+
+      val (pub, sub) = TestSource.probe[Long]
+        .via(testedFlow)
+        .toMat(TestSink.probe[Long])(Keep.both)
+        .run()
+
+      sub.request(n = 10)
+      pub.sendNext(10L)
+      sub.expectNext(10L, 9L, 8L, 7L, 6L, 5L)
+      pub.sendNext(4L)
+      sub.expectNext(4L)
+      pub.sendNext(3L)
+      sub.expectNext(3L)
+    }
+
+    "be able to compute the Fibonacci sequence" in {
+      import PartitionWith.Implicits._
+      import FeedbackLoop.Implicits._
+
+      val forwardFlow = Flow[(Int, Int)]
+        .mapConcat { case pair @ (n, _) => Right(n) :: Left(pair) :: Nil }
+        .partitionWith(identity)
+      val feedbackArc = Flow[(Int, Int)]
+        .map { case (n, n1) => (n1, n + n1) }
+      val testedFlow = forwardFlow.feedbackVia(feedbackArc, 1)
+
+      val (pub, sub) = TestSource.probe[(Int, Int)]
+        .via(testedFlow)
+        .toMat(TestSink.probe[Int])(Keep.both)
+        .run()
+
+      sub.request(n = 20)
+      pub.sendNext((0, 1))
+      sub.expectNextN(List(0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181))
+    }
+  }
+}


### PR DESCRIPTION
The motivation is to provide a safe way to create feedback loops. Deadlock is never the desired behavior, yet they are tricky to avoid when creating cycles manually.

The trick to avoid deadlocks is to never backpressure the feedback loop (and prefer failure when the buffer overflows).