### PR TITLE
Drop support for Akka 2.4.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ deploy:
 
 env:
   matrix:
-    - AKKA_SERIES=2.4
     - AKKA_SERIES=2.5
   global:
     - BINTRAY_USER=raboofje

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -15,7 +15,7 @@ object Common extends AutoPlugin {
 
   val AkkaVersion = sys.env.get("AKKA_SERIES") match {
     case Some("2.5") => "2.5.13"
-    case _ => "2.4.18"
+    case _ => "2.5.13"
   }
 
   override def trigger = allRequirements


### PR DESCRIPTION
No longer require sources to compile with Akka 2.4 series.

@raboof in #151:

> I think it would be OK to drop support for Akka 2.4 in this library, given 2.5 has now been out for almost 2 years

Generally, it seems OK to me to require some minimal Akka version for each akka-stream-contrib version, as thanks to Akka's backward compatibility users should be able to safely update their Akka version as well.