### PR TITLE
Add alias for releasing commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ jobs:
       name: "Run tests for all Scala versions"
 
     - stage: publish-211
-      env: CMD="++2.11.12 publishSigned sonatypeRelease"
+      env: CMD="++2.11.12 release"
       name: "Publish artifacts for Scala 2.11 to Sonatype and release"
 
     - stage: publish-212
-      env: CMD="++2.12.8 publishSigned sonatypeRelease"
+      env: CMD="++2.12.8 release"
       name: "Publish artifacts for Scala 2.12 to Sonatype and release"
 
     - stage: publish-213
-      env: CMD="++2.13.0 publishSigned sonatypeRelease"
+      env: CMD="++2.13.0 release"
       name: "Publish artifacts for Scala 2.13 to Sonatype and release"
 
 stages:

--- a/build.sbt
+++ b/build.sbt
@@ -70,3 +70,5 @@ testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 enablePlugins(AutomateHeaderPlugin)
 headerLicense := Some(HeaderLicense.Custom(s"Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>"))
 scalafmtOnCompile := true
+
+addCommandAlias("release", ";publishSigned ;sonatypeRelease")


### PR DESCRIPTION
## Purpose

Use alias, instead of multiple tasks.

## References

Fixes #161

## Background Context

Cross-building multiple commands needs an command alias.