### PR TITLE
Introduce token throttle flow

### DIFF
--- a/src/main/scala/akka/stream/contrib/TokenThrottle.scala
+++ b/src/main/scala/akka/stream/contrib/TokenThrottle.scala
@@ -18,26 +18,26 @@ import akka.util.OptionVal._
  * Tokens are consumed as-needed, and pre-fetched once the internal token buffer is empty. Also, an initial fetch is
  * performed to initially fill the internal token bucket.
  *
- * '''Emits when''' when an input element <em>e</em> is available and <em>costCalculation(e)</em> tokens are available.
+ * '''Emits when''' an input element <em>e</em> is available and <em>costCalculation(e)</em> tokens are available
  *
  * '''Backpressures when''' downstream backpressures, or when not enough tokens are available for the next element. For
- * the token input: when no tokens are needed (tokens are pulled as needed).
+ * the token input: when no tokens are needed (tokens are pulled as needed)
  *
- * '''Completes when''' a) element upstream completes, or b) when token upstream completes and all internally stored
- * tokens were consumed (best effort; also completes when the next element cost is higher than the available tokens).
+ * '''Completes when''' upstream completes, and also when token source completes and all internally stored tokens were
+ * consumed (best effort; also completes when the next element cost is higher than the available tokens)
  *
- * '''Cancels when''' downstream cancels.
+ * '''Cancels when''' downstream cancels
  */
 object TokenThrottle {
 
   /**
    * Creates a token-based throttling flow.
    *
-   * @param tokenSource source of tokens to use for controlling throughput.
+   * @param tokenSource source of tokens to use for controlling throughput
    * @param costCalculation cost function that determines the cost of a given element
    * @tparam A element type
    * @tparam M materialized value of token source
-   * @return simple token throttle graph.
+   * @return simple token throttle graph
    */
   def apply[A, M](tokenSource: Graph[SourceShape[Long], M])(costCalculation: A => Long): Graph[FlowShape[A, A], M] =
     GraphDSL.create(tokenSource) { implicit b => tokens =>

--- a/src/main/scala/akka/stream/contrib/TokenThrottle.scala
+++ b/src/main/scala/akka/stream/contrib/TokenThrottle.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import akka.stream.scaladsl.GraphDSL
+import akka.stream.{Attributes, FanInShape2, FlowShape, Graph, Inlet, Outlet, SourceShape}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.util.OptionVal
+import akka.util.OptionVal._
+
+/**
+ * Throttles a flow based on tokens provided consumed from a provided token source. The flow emits elements only if
+ * the needed amount of tokens for the next element is available. The amount of tokens needed is specified by a cost
+ * function.
+ *
+ * Tokens are consumed as-needed, and pre-fetched once the internal token buffer is empty. Also, an initial fetch is
+ * performed to initially fill the internal token bucket.
+ *
+ * '''Emits when''' when an input element <em>e</em> is available and <em>costCalculation(e)</em> tokens are available.
+ *
+ * '''Backpressures when''' downstream backpressures, or when not enough tokens are available for the next element. For
+ * the token input: when no tokens are needed (tokens are pulled as needed).
+ *
+ * '''Completes when''' a) element upstream completes, or b) when token upstream completes and all internally stored
+ * tokens were consumed (best effort; also completes when the next element cost is higher than the available tokens).
+ *
+ * '''Cancels when''' downstream cancels.
+ */
+object TokenThrottle {
+
+  /**
+   * Creates a token-based throttling flow.
+   *
+   * @param tokenSource source of tokens to use for controlling throughput.
+   * @param costCalculation cost function that determines the cost of a given element
+   * @tparam A element type
+   * @tparam M materialized value of token source
+   * @return simple token throttle graph.
+   */
+  def apply[A, M](tokenSource: Graph[SourceShape[Long], M])(costCalculation: A => Long): Graph[FlowShape[A, A], M] =
+    GraphDSL.create(tokenSource) { implicit b => tokens =>
+      import GraphDSL.Implicits._
+      val throttle = b.add(new TokenThrottle[A](costCalculation))
+      tokens ~> throttle.in1
+      FlowShape(throttle.in0, throttle.out)
+    }
+}
+
+/**
+ * Graph stage for token-based throttling. Use it directly for constructing more complex graphs.
+ *
+ * @param costCalculation cost function that determines the cost of a given element
+ * @tparam A element type
+ */
+final class TokenThrottle[A](costCalculation: A => Long) extends GraphStage[FanInShape2[A, Long, A]] {
+  override def initialAttributes: Attributes = Attributes.name("TokenThrottle")
+
+  override val shape: FanInShape2[A, Long, A] = new FanInShape2[A, Long, A]("TokenThrottle")
+
+  def out: Outlet[A] = shape.out
+
+  val elemsIn: Inlet[A] = shape.in0
+  val tokensIn: Inlet[Long] = shape.in1
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    var tokens: Long = 0
+
+    var buffer: OptionVal[A] = none
+
+    var cost: Long = -1 // invariant: buffer.isDefined => cost == costCalculation(buffer.get)
+
+    var tokensCompleted = false
+
+    var elemsCompleted = false
+
+    private def maybeEmit(): Unit =
+      if (tokensExhaused) {
+        completeStage()
+      } else if (isAvailable(out) && buffer.isDefined) {
+        if (tokens >= cost) {
+          tokens -= cost
+          push(out, buffer.get)
+          buffer = none
+          if (elemsCompleted || tokensExhaused) {
+            completeStage()
+          } else {
+            pull(elemsIn)
+            if (tokens == 0) askForTokens()
+          }
+        } else {
+          if (!tokensCompleted) askForTokens() else completeStage()
+        }
+      }
+
+    private def tokensExhaused = tokensCompleted && tokens == 0
+
+    private def askForTokens(): Unit = if (!tokensCompleted && !hasBeenPulled(tokensIn)) pull(tokensIn)
+
+    override def preStart(): Unit = {
+      pull(elemsIn)
+      pull(tokensIn)
+    }
+
+    setHandler(
+      elemsIn,
+      new InHandler {
+        override def onPush(): Unit = {
+          val elem = grab(elemsIn)
+          buffer = Some(elem)
+          cost = costCalculation(elem) // pre-compute cost here to call cost function only once per element
+          if (cost < 0) throw new IllegalArgumentException("Cost must be non-negative")
+          maybeEmit()
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          if (buffer.isEmpty) completeStage()
+          elemsCompleted = true
+        }
+      }
+    )
+
+    setHandler(
+      tokensIn,
+      new InHandler {
+        override def onPush(): Unit = {
+          tokens += grab(tokensIn)
+          maybeEmit()
+        }
+
+        override def onUpstreamFinish(): Unit = {
+          tokensCompleted = true
+          maybeEmit()
+        }
+      }
+    )
+
+    setHandler(out, new OutHandler {
+      override def onPull(): Unit = maybeEmit()
+    })
+  }
+}

--- a/src/test/scala/akka/stream/contrib/TokenThrottleSpec.scala
+++ b/src/test/scala/akka/stream/contrib/TokenThrottleSpec.scala
@@ -58,7 +58,7 @@ class TokenThrottleSpec extends WordSpec with MustMatchers with ScalaFutures {
       val tokens = Source.repeat(1L).alsoTo(Sink.foreach(_ => tokenAsked.incrementAndGet()))
 
       val sum = Source
-        .fromIterator(() => LazyList.from(1, 1).iterator)
+        .fromIterator(() => Stream.from(1, 1).iterator)
         .take(40)
         .via(TokenThrottle(tokens)(_.toLong))
         .runWith(Sink.fold(0)(_ + _))

--- a/src/test/scala/akka/stream/contrib/TokenThrottleSpec.scala
+++ b/src/test/scala/akka/stream/contrib/TokenThrottleSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.stream.testkit.{TestPublisher, TestSubscriber}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{MustMatchers, WordSpec}
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration._
+
+class TokenThrottleSpec extends WordSpec with MustMatchers with ScalaFutures {
+
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val mat: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+  "token throttle" should {
+
+    "let elements pass only when tokens are available" in {
+      val (elems, tokens, out) = throttledGraph
+
+      tokens.sendNext(2)
+      elems.sendNext(1)
+      out.requestNext() mustBe 1
+      elems.sendNext(2)
+      out.requestNext() mustBe 2
+      elems.sendNext(3)
+      out.expectNoMessage(100.millis)
+      tokens.sendNext(1)
+      out.requestNext() mustBe 3
+    }
+
+    "ask for tokens only when tokens are needed" in {
+      val tokenAsked = new AtomicInteger()
+      val tokens = Source.repeat(10L).take(20).alsoTo(Sink.foreach(_ => tokenAsked.incrementAndGet()))
+
+      Source
+        .repeat(1)
+        .take(25)
+        .via(TokenThrottle(tokens)(_ => 1))
+        .runWith(Sink.ignore)
+        .futureValue
+
+      tokenAsked.get() mustBe 3
+    }
+
+    "consume tokens according to cost" in {
+      val tokenAsked = new AtomicInteger()
+      val tokens = Source.repeat(1L).alsoTo(Sink.foreach(_ => tokenAsked.incrementAndGet()))
+
+      val sum = Source
+        .fromIterator(() => LazyList.from(1, 1).iterator)
+        .take(40)
+        .via(TokenThrottle(tokens)(_.toLong))
+        .runWith(Sink.fold(0)(_ + _))
+        .futureValue
+
+      tokenAsked.get() mustBe sum
+    }
+
+    "complete when all tokens are consumed" in {
+      val (elems, tokens, out) = throttledGraph
+
+      tokens.sendNext(2)
+      elems.sendNext(1)
+      out.requestNext() mustBe 1
+      tokens.sendComplete()
+
+      elems.sendNext(2)
+      out.requestNext() mustBe 2
+      out.expectComplete()
+    }
+
+    "complete when elements are consumed" in {
+
+      val (elems, tokens, out) = throttledGraph
+
+      tokens.sendNext(10)
+      elems.sendNext(1)
+      out.requestNext() mustBe 1
+      elems.sendNext(2)
+      out.requestNext() mustBe 2
+      elems.sendComplete()
+      out.expectComplete()
+    }
+  }
+
+  def throttledGraph: (TestPublisher.Probe[Int], TestPublisher.Probe[Long], TestSubscriber.Probe[Int]) = {
+    val ((elems, tokens), out) = TestSource
+      .probe[Int]
+      .viaMat(TokenThrottle(TestSource.probe[Long])(_ => 1))(Keep.both)
+      .toMat(TestSink.probe)(Keep.both)
+      .run()
+    (elems, tokens, out)
+  }
+}

--- a/src/test/scala/akka/stream/contrib/TokenThrottleSpec.scala
+++ b/src/test/scala/akka/stream/contrib/TokenThrottleSpec.scala
@@ -34,7 +34,7 @@ class TokenThrottleSpec extends WordSpec with MustMatchers with ScalaFutures {
       elems.sendNext(2)
       out.requestNext() mustBe 2
       elems.sendNext(3)
-      out.expectNoMessage(100.millis)
+      an[AssertionError] shouldBe thrownBy(out.requestNext(100.millis)) // expect element to be blocked
       tokens.sendNext(1)
       out.requestNext() mustBe 3
     }


### PR DESCRIPTION
Allows to use a centrally managed token bucket that distributes tokens
to multiple flows. Provides both a GraphStage for this kind of setup as
well as a Flow factory for a simpler setup where tokens are provided via
a Source.

Fixes #166