### PR TITLE
Flow to merge streams to ZIP file

### DIFF
--- a/src/main/scala/akka/stream/contrib/MergeToZipFile.scala
+++ b/src/main/scala/akka/stream/contrib/MergeToZipFile.scala
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import java.util.zip.{ZipEntry, ZipOutputStream}
+import akka.NotUsed
+import akka.stream._
+import akka.stream.scaladsl.{Flow, Source}
+import akka.stream.stage._
+import akka.util.{ByteString, ByteStringBuilder}
+
+/**
+ *  Merges many file streams into one stream with ZIP file.
+ *
+ *  One file is represented as a tuple (String, Source[ByteString, NotUsed]).
+ *  This matches Alpakka S3 connector implementation. Can be used for e.g. download many S3 files in one ZIP file.
+ *
+ *  Connected with source of type Source[(String, Source[ByteString, NotUsed]), NotUsed] will result in Source[ByteString, NotUsed].
+ */
+object MergeToZipFile {
+
+  private val startFileWord = "$START$"
+  private val endFileWord = "$END$"
+  private val separator: Char = '|'
+
+  private val zipStage = new FileZipStage()
+
+  def flow(): Flow[(String, Source[ByteString, Any]), ByteString, NotUsed] =
+    Flow[(String, Source[ByteString, Any])]
+      .flatMapConcat {
+        case (path, stream) =>
+          val prependElem: Source[ByteString, Any] = Source.single(createStartingByteString(path))
+          val appendElem: Source[ByteString, Any] = Source.single(ByteString(endFileWord))
+          stream.prepend(prependElem).concat(appendElem).via(zipStage)
+      }
+
+  private def createStartingByteString(path: String): ByteString =
+    ByteString(s"$startFileWord$separator$path")
+
+  private def getPathFromByteString(b: ByteString): String = {
+    val splitted = b.utf8String.split(separator)
+    if (splitted.length == 1) {
+      ""
+    } else if (splitted.length == 2) {
+      splitted.tail.head
+    } else {
+      splitted.tail.mkString(separator.toString)
+    }
+  }
+
+  class FileZipStage extends GraphStage[FlowShape[ByteString, ByteString]] {
+    val in: Inlet[ByteString] = Inlet("FileZipStage.in")
+    val out: Outlet[ByteString] = Outlet("FileZipStage.out")
+    override val shape: FlowShape[ByteString, ByteString] = FlowShape.of(in, out)
+
+    override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+      private val builder = new ByteStringBuilder()
+      private val zip = new ZipOutputStream(builder.asOutputStream)
+      private var emptyStream = true
+
+      setHandler(
+        out,
+        new OutHandler {
+          override def onPull(): Unit =
+            if (isClosed(in)) {
+              val result = builder.result
+              if (result.nonEmpty) {
+                push(out, result)
+              }
+              builder.clear()
+              completeStage()
+            } else {
+              pull(in)
+            }
+        }
+      )
+
+      setHandler(
+        in,
+        new InHandler {
+          override def onPush(): Unit = {
+            emptyStream = false
+            val element = grab(in)
+            element match {
+              case b: ByteString if b.utf8String.startsWith(MergeToZipFile.startFileWord) =>
+                val name = MergeToZipFile.getPathFromByteString(b)
+                zip.putNextEntry(new ZipEntry(name))
+              case b: ByteString if b.utf8String == MergeToZipFile.endFileWord =>
+                zip.closeEntry()
+              case b: ByteString =>
+                val array = b.toArray
+                zip.write(array, 0, array.length)
+            }
+            zip.flush()
+            val result = builder.result
+            if (result.nonEmpty) {
+              builder.clear()
+              push(out, result)
+            } else {
+              pull(in)
+            }
+          }
+
+          override def onUpstreamFinish(): Unit =
+            if (emptyStream) {
+              zip.close()
+              super.onUpstreamFinish()
+            }
+        }
+      )
+    }
+  }
+}

--- a/src/test/scala/akka/stream/contrib/MergeToZipFileSpec.scala
+++ b/src/test/scala/akka/stream/contrib/MergeToZipFileSpec.scala
@@ -21,7 +21,7 @@ class MergeToZipFileSpec extends BaseStreamSpec with ScalaFutures {
   "MergeToZipFileFlow" should {
 
     "merge file to zip file" in {
-      val inputFiles = generateInputFiles(5, 1000)
+      val inputFiles = generateInputFiles(5, 100)
       val inputStream = filesToStream(inputFiles)
 
       val akkaZipped: Future[ByteString] =

--- a/src/test/scala/akka/stream/contrib/MergeToZipFileSpec.scala
+++ b/src/test/scala/akka/stream/contrib/MergeToZipFileSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.util.zip.ZipInputStream
+
+import akka.NotUsed
+import akka.stream.scaladsl.{Sink, Source}
+import akka.util.ByteString
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.Future
+
+class MergeToZipFileSpec extends BaseStreamSpec with ScalaFutures {
+
+  val zipFlow = MergeToZipFile.flow()
+
+  "MergeToZipFileFlow" should {
+
+    "merge file to zip file" in {
+      val inputFiles = generateInputFiles(5, 1000)
+      val inputStream = filesToStream(inputFiles)
+
+      val akkaZipped: Future[ByteString] =
+        inputStream
+          .via(zipFlow)
+          .runWith(Sink.fold(ByteString.empty)(_ ++ _))
+
+      unzip(akkaZipped.futureValue) shouldBe inputFiles
+    }
+
+    "handle empty stream" in {
+      val sources = Source.empty
+
+      val akkaZipped: Future[ByteString] =
+        sources
+          .via(zipFlow)
+          .runWith(Sink.fold(ByteString.empty)(_ ++ _))
+
+      akkaZipped.futureValue shouldBe ByteString.empty
+    }
+  }
+
+  private def generateInputFiles(numberOfFiles: Int, lengthOfFile: Int): Map[String, Seq[Byte]] = {
+    val r = new scala.util.Random(31)
+    (1 to numberOfFiles).map(number => s"file-$number" -> r.nextString(lengthOfFile).getBytes.toSeq).toMap
+  }
+
+  private def filesToStream(files: Map[String, Seq[Byte]]): Source[(String, Source[ByteString, NotUsed]), NotUsed] = {
+    val sourceFiles = files.toList.map {
+      case (title, content) =>
+        (title, Source(content.grouped(10).map(group => ByteString(group.toArray)).toList))
+    }
+    Source(sourceFiles)
+  }
+
+  private def unzip(bytes: ByteString): Map[String, Seq[Byte]] = {
+    var result: Map[String, Seq[Byte]] = Map.empty
+
+    val zis = new ZipInputStream(new ByteArrayInputStream(bytes.toArray))
+    val buffer = new Array[Byte](1024)
+
+    try {
+      var zipEntry = zis.getNextEntry
+      while (zipEntry != null) {
+        val baos = new ByteArrayOutputStream()
+        val name = zipEntry.getName
+
+        var len = zis.read(buffer)
+
+        while (len > 0) {
+          baos.write(buffer, 0, len)
+          len = zis.read(buffer)
+        }
+        result += (name -> baos.toByteArray.toSeq)
+        baos.close()
+        zipEntry = zis.getNextEntry
+      }
+    } finally {
+      zis.closeEntry()
+      zis.close()
+    }
+    result
+  }
+}


### PR DESCRIPTION
## Purpose

Flow to merge streams to ZIP file.
My usage was to download files from S3 and pass them to the user as ZIP file.

Similar to:
https://github.com/akka/akka-stream-contrib/pull/170
But does not requires InputStream as input (and blocking a thread for creating them https://doc.akka.io/docs/akka/current/stream/operators/index.html#additional-sink-and-source-converters).

Base on my work in:
https://gist.github.com/michalbogacz/08868f51b7053cadfef00f51196bf2ec

