### PR TITLE
MergeByIndex fan-in stage

### DIFF
--- a/src/main/scala/akka/stream/contrib/MergeByIndex.scala
+++ b/src/main/scala/akka/stream/contrib/MergeByIndex.scala
@@ -1,0 +1,174 @@
+package akka.stream.contrib
+
+import akka.stream.impl.Stages.DefaultAttributes
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.{Attributes, Inlet, Outlet, UniformFanInShape}
+
+import scala.collection.{immutable, mutable}
+
+/**
+ * Merges multiple incoming inputs based on a total ordering extracted from the elements.
+ *
+ * Merging is done by keeping track of an expected next index value (starting with zero and monotonically increasing).
+ * The merging is able to cope with gaps in the index sequence that emerge from filtering out elements before merging.
+ * This stage buffers up to <code>inputPorts</code> elements before emitting.
+ *
+ * '''Emits when''' one input element <em>e</em> consumed has <em>index(e)</em> being the next expected index, or when
+ * all input ports have provided elements; in this case, an index omission is assumed, and the element with the lowest
+ * index is emitted
+ *
+ * '''Backpressures when''' downstream backpressures, and one element from each input port has been buffered
+ *
+ * '''Completes when''' all upstreams complete and all buffered elements were emitted
+ *
+ * '''Cancels when''' downstream cancels
+ *
+ * '''Errors when''' the index sequence isn't strict monotonically increasing (e.g. if it contains duplicate index values)
+ */
+object MergeByIndex {
+
+  /**
+   * Creates a merge-by-index stage for tuples with second component of type Long (e.g. as created by <code>.zipWithIndex</code>)
+   *
+   * @param inputPorts number of inputs to merge
+   * @tparam T type of the first tuple component
+   * @return a merge stage that orders tuples by their second component.
+   */
+  def apply[T](inputPorts: Int): MergeByIndex[(T, Long)] = new MergeByIndex[(T, Long)](inputPorts, _._2)
+
+  /**
+   * Creates a merge-by-index stage where the index of elements is determined by the <code>index</code> function.
+   *
+   * @param inputPorts the number of inputs to merge
+   * @param index extractor function yielding the index of an element
+   * @tparam T type of elements to merge
+   * @return a merge stage that orders tuples by their index as specified by the index extractor function.
+   */
+  def apply[T](inputPorts: Int, index: T => Long): MergeByIndex[T] = new MergeByIndex[T](inputPorts, index)
+}
+
+/**
+ * A merge stage that respects element ordering as given by their index.
+ *
+ * @param inputPorts number of inputs to merge
+ * @param index extractor function yielding the index of an element
+ * @tparam T type of elements to merge
+ */
+final class MergeByIndex[T](val inputPorts: Int, index: T => Long) extends GraphStage[UniformFanInShape[T, T]] {
+
+  // one input might seem counter intuitive but saves us from special handling in other places
+  require(inputPorts >= 1, "A MergeByIndex must have one or more input ports")
+
+  val in: immutable.IndexedSeq[Inlet[T]] = Vector.tabulate(inputPorts)(i => Inlet[T]("MergeByIndex.in" + i))
+  val out: Outlet[T] = Outlet[T]("MergeByIndex.out")
+
+  override def initialAttributes: Attributes = DefaultAttributes.merge
+  override val shape: UniformFanInShape[T, T] = UniformFanInShape(out, in: _*)
+
+  private type QueueT = (T, Long, Int)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    // keeps track of the next expected index
+    private var expectedIndex: Long = 0L
+
+    // buffers pulled elements in order of their index
+    private val buffer = mutable.PriorityQueue.empty(Ordering.by((i: QueueT) => i._2).reverse)
+
+    // keeps track of closed inlets that have elements in the buffer - relevant for correctly handling index omissions
+    // when upstreams start to complete
+    private val bufferedClosedInlets = mutable.BitSet.empty
+
+    // keeps track of the maximum expected buffer length - relevant for handling index omissions
+    private var maxBufferLength = inputPorts
+
+    override def preStart(): Unit = {
+      var ix = 0
+      while (ix < in.size) {
+        tryPull(in(ix))
+        ix += 1
+      }
+    }
+
+    private def maybeEmit(): Unit = {
+      if (buffer.nonEmpty) {
+        if (buffer.head._2 == expectedIndex) {
+          emitAndPull(buffer.dequeue())
+        } else if (dataFromAllInletsBuffered) {
+          // if all inlets pushed data and we didn't find the expected index, we know this is an index omission.
+          // it is therefore fine and necessary to emit the element with the smallest index seen.
+          emitAndPull(buffer.dequeue())
+        }
+      }
+
+      if (noMoreDataExpected) completeStage()
+    }
+
+    private def dataFromAllInletsBuffered = buffer.length == maxBufferLength
+
+    private def updateMaxBufferLength(): Unit =
+      // needs to account for open inlets and data of closed inlets that is already buffered.
+      // only if this amount of items are in the buffer, we have received data from all upstreams and it is safe
+      // to deduce an index omission.
+      maxBufferLength = in.count(i => !isClosed(i)) + bufferedClosedInlets.size
+
+    private def noMoreDataExpected = maxBufferLength == 0
+
+    private def emitAndPull(queueElem: (T, Long, Int)): Unit = {
+      val (elem, index, inletIndex) = queueElem
+      val inlet = in(inletIndex)
+      verifyElementIndex(index, inlet)
+      push(out, elem)
+      if (!isClosed(inlet)) {
+        pull(inlet)
+      } else {
+        // Optimization: check this only if inlet is closed.
+        if (bufferedClosedInlets.contains(inletIndex)) {
+          // in case this inlet was closed and data was buffered, it isn't any more now.
+          bufferedClosedInlets.subtractOne(inletIndex)
+          updateMaxBufferLength()
+        }
+      }
+      expectedIndex = index + 1
+    }
+
+    private def verifyElementIndex(elemIndex: Long, in: Inlet[T]): Unit =
+      if (elemIndex < expectedIndex)
+        throw new IllegalArgumentException(
+          s"Index sequence is non-monotonic: element received from ${in.s} with index $elemIndex has smaller than currently expected index $expectedIndex"
+        )
+
+    {
+      var ix = 0
+      while (ix < in.size) {
+        val i = in(ix)
+        setHandler(i, createInHandler(ix, i))
+        ix += 1
+      }
+    }
+
+    private def createInHandler(pos: Int, in: Inlet[T]) = new InHandler {
+      override def onPush(): Unit = {
+        val elem = grab(in)
+        val elemIndex = index(elem)
+        verifyElementIndex(elemIndex, in)
+        buffer.addOne((elem, elemIndex, pos))
+        if (isAvailable(out)) maybeEmit()
+      }
+
+      override def onUpstreamFinish(): Unit = {
+        // for properly handling index omissions we need to remember how many items from closed inlets are buffered.
+        if (buffer.exists(_._3 == pos)) bufferedClosedInlets.addOne(pos)
+        updateMaxBufferLength()
+        if (isAvailable(out)) maybeEmit() // a finished upstream may unblock emitting.
+        else if (noMoreDataExpected) completeStage()
+      }
+    }
+
+    setHandler(out, new OutHandler {
+      override def onPull(): Unit = maybeEmit()
+    })
+  }
+
+  override def toString = "MergeByIndex"
+}

--- a/src/test/scala/akka/stream/contrib/MergeByIndexSpec.scala
+++ b/src/test/scala/akka/stream/contrib/MergeByIndexSpec.scala
@@ -1,3 +1,7 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.stream.contrib
 
 import akka.NotUsed
@@ -107,7 +111,7 @@ class MergeByIndexSpec extends WordSpec with MustMatchers with ScalaFutures {
       val flow = Flow.fromGraph(GraphDSL.create() { implicit builder: GraphDSL.Builder[NotUsed] =>
         import GraphDSL.Implicits._
 
-        val partition = builder.add(Partition[Long](branchCount, _ => Random.between(0, branchCount)))
+        val partition = builder.add(Partition[Long](branchCount, _ => Random.nextInt(branchCount)))
         val merge = builder.add(MergeByIndex(branchCount, identity[Long]))
         val buffer = Flow[Long].buffer(3 * inputLength / branchCount, OverflowStrategy.backpressure)
 
@@ -117,7 +121,7 @@ class MergeByIndexSpec extends WordSpec with MustMatchers with ScalaFutures {
       })
 
       for (_ <- 1 to testRepetitions) {
-        val input = List.tabulate(inputLength)(_.toLong).filterNot(_ => Random.between(0, 5) == 0) // add random gaps
+        val input = List.tabulate(inputLength)(_.toLong).filterNot(_ => Random.nextInt(5) == 0) // add random gaps
         val output = Source(input).via(flow).runWith(Sink.seq).futureValue
         output mustBe input
       }

--- a/src/test/scala/akka/stream/contrib/MergeByIndexSpec.scala
+++ b/src/test/scala/akka/stream/contrib/MergeByIndexSpec.scala
@@ -1,0 +1,174 @@
+package akka.stream.contrib
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{Flow, GraphDSL, Partition, RunnableGraph, Sink, Source}
+import akka.stream.testkit.{TestPublisher, TestSubscriber}
+import akka.stream.{ActorMaterializer, ClosedShape, FlowShape, OverflowStrategy}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{MustMatchers, WordSpec}
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+//noinspection TypeAnnotation
+class MergeByIndexSpec extends WordSpec with MustMatchers with ScalaFutures {
+  implicit val system = ActorSystem("merge-by-index")
+  implicit val mat = ActorMaterializer()
+  implicit override val patienceConfig = PatienceConfig(5.seconds)
+
+  "MergeByIndex" should {
+
+    "pull from all upstreams" in new ThreeWayMergeGraph {
+      // expecting subscriptions is already performed in ThreeWayMergeGraph
+      completeAll()
+    }
+
+    "merge elements in order" in new ThreeWayMergeGraph {
+      in1.sendNext(1L)
+      in2.sendNext(0L)
+      requestedNextOne() mustBe 0L
+      requestedNextOne() mustBe 1L
+      completeAll()
+    }
+
+    "wait for missing index if not all inputs are available" in new ThreeWayMergeGraph {
+      in1.sendNext(1L)
+      noNextOne() // waits for index 0.
+
+      in3.sendNext(2L)
+      out.expectNoMessage(50.millis) // still waits for index 0.
+
+      in2.sendNext(0L)
+      nextOne() mustBe 0L // emits index 0.
+      requestedNextOne() mustBe 1L // emits index 1.
+      requestedNextOne() mustBe 2L // emits index 2.
+      completeAll()
+    }
+
+    "emit element on index omission" in new ThreeWayMergeGraph {
+      in1.sendNext(1L)
+      noNextOne() // waits for index 0.
+
+      in2.sendNext(2L)
+      in3.sendNext(3L)
+      nextOne() mustBe 1L // emits index 1 as we now know there's a gap.
+      completeAll()
+    }
+
+    "complete only when all inputs complete" in new ThreeWayMergeGraph {
+      in3.sendNext(1L)
+      in2.sendNext(0L)
+      in1.sendNext(2L)
+
+      requestedNextOne()
+      requestedNextOne()
+      requestedNextOne()
+
+      in2.sendComplete()
+      out.expectNoMessage(50.millis)
+
+      in1.sendComplete()
+      out.expectNoMessage(50.millis)
+
+      in3.sendComplete()
+      out.expectComplete()
+    }
+
+    "error if index sequence is non-monotonic" in new ThreeWayMergeGraph {
+      in1.sendNext(1L)
+      in2.sendNext(0L)
+      requestedNextOne() mustBe 0L
+      requestedNextOne() mustBe 1L
+
+      in3.sendNext(1L)
+      out.expectError() mustBe a[IllegalArgumentException]
+    }
+
+    "emit element on completion after index omission" in new ThreeWayMergeGraph {
+      in1.sendNext(2L)
+      in2.sendNext(1L) // index 0 is omitted
+      in3.sendComplete() // ... which the stage should now infer due to completion of in3
+
+      requestedNextOne() mustBe 1L
+      requestedNextOne() mustBe 2L
+      in2.sendComplete()
+      in1.sendComplete()
+
+      out.expectComplete()
+    }
+
+    "always merge items in order" in {
+      // using poor man's property-based testing
+      val inputLength = 1000
+      val testRepetitions = 50
+      val branchCount = 20
+
+      val flow = Flow.fromGraph(GraphDSL.create() { implicit builder: GraphDSL.Builder[NotUsed] =>
+        import GraphDSL.Implicits._
+
+        val partition = builder.add(Partition[Long](branchCount, _ => Random.between(0, branchCount)))
+        val merge = builder.add(MergeByIndex(branchCount, identity[Long]))
+        val buffer = Flow[Long].buffer(3 * inputLength / branchCount, OverflowStrategy.backpressure)
+
+        for (_ <- 1 to branchCount) partition ~> buffer ~> merge
+
+        FlowShape(partition.in, merge.out)
+      })
+
+      for (_ <- 1 to testRepetitions) {
+        val input = List.tabulate(inputLength)(_.toLong).filterNot(_ => Random.between(0, 5) == 0) // add random gaps
+        val output = Source(input).via(flow).runWith(Sink.seq).futureValue
+        output mustBe input
+      }
+    }
+  }
+
+  trait ThreeWayMergeGraph {
+    val pub1 = TestPublisher.manualProbe[Long]()
+    val pub2 = TestPublisher.manualProbe[Long]()
+    val pub3 = TestPublisher.manualProbe[Long]()
+    val out = TestSubscriber.manualProbe[Long]()
+
+    val graph = RunnableGraph.fromGraph(GraphDSL.create() { implicit builder: GraphDSL.Builder[NotUsed] =>
+      import GraphDSL.Implicits._
+      val in1 = Source.fromPublisher(pub1)
+      val in2 = Source.fromPublisher(pub2)
+      val in3 = Source.fromPublisher(pub3)
+      val outSink = Sink.fromSubscriber(out)
+
+      val merge = builder.add(MergeByIndex(3, identity[Long]))
+
+      in1 ~> merge ~> outSink
+      in2 ~> merge
+      in3 ~> merge
+      ClosedShape
+    })
+
+    graph.run()
+
+    val in1 = pub1.expectSubscription()
+    val in2 = pub2.expectSubscription()
+    val in3 = pub3.expectSubscription()
+
+    val subscription = out.expectSubscription()
+
+    def requestedNextOne(): Long = {
+      subscription.request(1)
+      out.expectNext()
+    }
+
+    def nextOne(): Long = out.expectNext()
+
+    def noNextOne(): Unit = {
+      subscription.request(1)
+      out.expectNoMessage(50.millis)
+    }
+
+    def completeAll(): Unit = {
+      in1.sendComplete()
+      in2.sendComplete()
+      in3.sendComplete()
+    }
+  }
+}


### PR DESCRIPTION
This pull requests proposes a new `MergeByIndex` stage for merging multiple upstreams by index (i.e. by total order). It supports a custom total order over incoming elements, and offers a convenience constructor for tuples created via `.zipWithIndex`. The stage requires a total ordering, and as such, fails fast as soon as it detects that the index is not strict monotonically increasing. `MergeByIndex` can handle index omissions that can be created by upstreams filtering out elements that shouldn't be further processed. It doesn't yet support eager completion; currently, it will complete only after all its upstreams completed and internally buffered elements are emitted.

Internally, `MergeByIndex` works by keeping track of the next expected index, starting at zero. It initially pulls from all its upstreams, and buffers fetched elements using a priority queue if they don't have the expected index. On index omission, the next expected index will however never arrive. This case can be handled by the stage once full information is available, i.e. once all upstreams have published an element. Once this happened without the expected index appearing,
it is safe to emit the element with the lowest index available. The logic for handling index omissions is a bit more elaborate to account for potential upstream completions, but the underlying principle remains the same.

Using a priority queue for buffering causes O(log inputPorts) added time complexity per element; note that this is also the best one can achieve with a well-balanced tree of `MergeSorted` stages.

Fixes #174 
