### PR TITLE
Introduce LatencyTimer operator.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ libraryDependencies ++= Seq(
   "junit" % "junit" % "4.12" % Test, // Common Public License 1.0
   "com.novocode" % "junit-interface" % "0.11" % Test, // BSD-like
   "com.google.jimfs" % "jimfs" % "1.1" % Test, // ApacheV2
-  "org.scalatest" %% "scalatest" % "3.0.8" % Test, // ApacheV2
+  "org.scalatest" %% "scalatest" % "3.1.0" % Test, // ApacheV2
+  "org.scalamock" %% "scalamock" % "4.4.0" % Test, // ApacheV2
   "com.miguno.akka" %% "akka-mock-scheduler" % "0.5.5" % Test // ApacheV2
 )
 

--- a/src/main/scala/akka/stream/contrib/latencyTimer.scala
+++ b/src/main/scala/akka/stream/contrib/latencyTimer.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import java.time.Clock
+import java.time.temporal.ChronoUnit
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.stream._
+import akka.stream.scaladsl.{Flow, GraphDSL, Sink}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
+import akka.stream.contrib.LatencyTimer._
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+private final class LatencyTimerStartStage[InOut](private val clock: Clock) extends GraphStage[TimerStartShape[InOut]] {
+
+  private[contrib] val in = Inlet.create[InOut]("LatencyTimerStart.In")
+  private[contrib] val out = Outlet.create[InOut]("LatencyTimerStart.Out")
+  private[contrib] val outTimerContext = Outlet.create[TimerContext]("LatencyTimerStart.OutTimerContext")
+
+  override val shape: TimerStartShape[InOut] = TimerStartShape(in, out, outTimerContext)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    setHandler(in, new InHandler {
+      override def onPush(): Unit = {
+        emit(outTimerContext, TimerContext(clock))
+        push(out, grab(in))
+      }
+    })
+
+    private[this] val outHandler = new OutHandler {
+      override def onPull(): Unit = if (!hasBeenPulled(in)) tryPull(in)
+    }
+
+    setHandler(out, outHandler)
+    setHandler(outTimerContext, outHandler)
+  }
+}
+
+private final class LatencyTimerEndStage[InOut] extends GraphStage[TimerEndShape[InOut]] {
+
+  private[contrib] val in = Inlet.create[InOut]("LatencyTimerEnd.In")
+  private[contrib] val inTimerContext = Inlet.create[TimerContext]("LatencyTimerEnd.InTimerContext")
+  private[contrib] val out = Outlet.create[InOut]("LatencyTimerEnd.Out")
+  private[contrib] val outTimedResult = Outlet.create[TimedResult[InOut]]("LatencyTimerEnd.TimedResult")
+
+  override val shape: TimerEndShape[InOut] = TimerEndShape(in, inTimerContext, out, outTimedResult)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic = new GraphStageLogic(shape) {
+
+    private[this] var timerContext = None: Option[TimerContext]
+
+    setHandler(
+      in,
+      new InHandler {
+        override def onPush(): Unit = {
+          val element = grab(in)
+          emit(outTimedResult, TimedResult(element, timerContext.get.stop()))
+          timerContext = None
+          push(out, element)
+        }
+      }
+    )
+
+    setHandler(inTimerContext, new InHandler {
+      override def onPush(): Unit = timerContext = Some(grab(inTimerContext))
+    })
+
+    setHandler(out, new OutHandler {
+      override def onPull(): Unit = tryPull(in)
+    })
+
+    setHandler(outTimedResult, new OutHandler {
+      override def onPull(): Unit = tryPull(inTimerContext)
+    })
+  }
+}
+
+/**
+ * {{{
+ *            +------------+
+ *            |            | ~> InOut
+ *   InOut ~> | TimerStart |
+ *            |            | ~> TimerContext
+ *            +------------+
+ * }}}
+ */
+private final case class TimerStartShape[InOut](in: Inlet[InOut],
+                                                out: Outlet[InOut],
+                                                outTimerContext: Outlet[TimerContext])
+    extends Shape {
+  override val inlets: Seq[Inlet[_]] = in :: Nil
+  override val outlets: Seq[Outlet[_]] = out :: outTimerContext :: Nil
+
+  override def deepCopy(): TimerStartShape[InOut] =
+    TimerStartShape(in.carbonCopy(), out.carbonCopy(), outTimerContext.carbonCopy())
+}
+
+/**
+ * {{{
+ *                   +------------+
+ *          InOut ~> |            | ~> InOut
+ *                   |  TimerEnd  |
+ *   TimerContext ~> |            | ~> TimedResult[InOut, FiniteDuration]
+ *                   +------------+
+ * }}}
+ */
+private final case class TimerEndShape[InOut](in: Inlet[InOut],
+                                              inTimerContext: Inlet[TimerContext],
+                                              out: Outlet[InOut],
+                                              outTimedResult: Outlet[TimedResult[InOut]])
+    extends Shape {
+  override val inlets: Seq[Inlet[_]] = in :: inTimerContext :: Nil
+  override val outlets: Seq[Outlet[_]] = out :: outTimedResult :: Nil
+
+  override def deepCopy(): TimerEndShape[InOut] =
+    TimerEndShape(in.carbonCopy(), inTimerContext.carbonCopy(), out.carbonCopy(), outTimedResult.carbonCopy())
+}
+
+private[contrib] object LatencyTimerStartStage {
+  def apply[T](clock: Clock): LatencyTimerStartStage[T] = new LatencyTimerStartStage[T](clock)
+}
+
+private[contrib] object LatencyTimerEndStage {
+  def apply[T](): LatencyTimerEndStage[T] = new LatencyTimerEndStage[T]()
+}
+
+object LatencyTimer {
+
+  private[contrib] case class TimerContext(clock: Clock) {
+    private val started = clock.instant()
+
+    def stop(): FiniteDuration = FiniteDuration(started.until(clock.instant(), ChronoUnit.NANOS), NANOSECONDS)
+  }
+
+  case class TimedResult[T](outcome: T, measuredTime: FiniteDuration)
+
+  @InternalApi // mainly for testing (mock Clock)
+  private[contrib] def createGraph[I, O, Mat](
+      flow: Flow[I, O, Mat],
+      sink: Graph[SinkShape[TimedResult[O]], Future[Done]]
+  )(clock: Clock): Flow[I, O, Mat] = {
+    val graph = GraphDSL.create(flow) { implicit builder: GraphDSL.Builder[Mat] =>
+      import GraphDSL.Implicits._
+      fl =>
+        // Junctions need to be created from blueprint via `builder.add(...)`
+        val startTimer = builder.add(LatencyTimerStartStage[I](clock))
+        val endTimer = builder.add(LatencyTimerEndStage[O]())
+
+        // @formatter:off
+        startTimer.out              ~> fl ~> endTimer.in
+        startTimer.outTimerContext  ~>       endTimer.inTimerContext; endTimer.outTimedResult ~> sink
+        // @formatter:on
+        FlowShape(startTimer.in, endTimer.out)
+    }
+    Flow.fromGraph(graph)
+  }
+
+  /**
+   * Wraps a given flow and measures the time between input and output. The measured result is pushed to a dedicated sink.
+   * The [[TimedResult]] contains the result of the wrapped flow as well in case some logic has to be done.
+   *
+   * Important Note: the wrapped flow must preserve the order, otherwise timing will be wrong.
+   *
+   * Consider bringing [[akka.stream.contrib.Implicits]] into scope for DSL support.
+   *
+   * @param flow the flow which will be measured
+   * @param sink a sink which will handle the [[TimedResult]]
+   * @tparam I   input-type of the wrapped flow
+   * @tparam O   output-type of the wrapped flow
+   * @tparam Mat materialized-type of the wrapped flow
+   * @return Flow of the the same shape as the wrapped flow
+   */
+  def apply[I, O, Mat](flow: Flow[I, O, Mat], sink: Graph[SinkShape[TimedResult[O]], Future[Done]]): Flow[I, O, Mat] =
+    createGraph(flow, sink)(Clock.systemDefaultZone())
+
+  /**
+   * Wraps a given flow and measures the time between input and output. The second parameter is the function which is called for each measured element.
+   * The [[TimedResult]] contains the result of the wrapped flow as well in case some logic has to be done.
+   *
+   * Important Note: the wrapped flow must preserve the order, otherwise timing will be wrong.
+   *
+   * Consider bringing [[akka.stream.contrib.Implicits]] into scope for DSL support.
+   *
+   * @param flow           the flow which will be measured
+   * @param resultFunction side-effect function which gets called with the result
+   * @tparam I   input-type of the wrapped flow
+   * @tparam O   output-type of the wrapped flow
+   * @tparam Mat materialized-type of the wrapped flow
+   * @return Flow of the the same shape as the wrapped flow
+   */
+  def apply[I, O, Mat](flow: Flow[I, O, Mat], resultFunction: TimedResult[O] => Unit): Flow[I, O, Mat] =
+    this(flow, Sink.foreach[TimedResult[O]](resultFunction))
+}

--- a/src/main/scala/akka/stream/contrib/latencyTimer.scala
+++ b/src/main/scala/akka/stream/contrib/latencyTimer.scala
@@ -95,8 +95,8 @@ private final case class TimerStartShape[InOut](in: Inlet[InOut],
                                                 out: Outlet[InOut],
                                                 outTimerContext: Outlet[TimerContext])
     extends Shape {
-  override val inlets: Seq[Inlet[_]] = in :: Nil
-  override val outlets: Seq[Outlet[_]] = out :: outTimerContext :: Nil
+  override val inlets: collection.immutable.Seq[Inlet[_]] = in :: Nil
+  override val outlets: collection.immutable.Seq[Outlet[_]] = out :: outTimerContext :: Nil
 
   override def deepCopy(): TimerStartShape[InOut] =
     TimerStartShape(in.carbonCopy(), out.carbonCopy(), outTimerContext.carbonCopy())
@@ -116,8 +116,8 @@ private final case class TimerEndShape[InOut](in: Inlet[InOut],
                                               out: Outlet[InOut],
                                               outTimedResult: Outlet[TimedResult[InOut]])
     extends Shape {
-  override val inlets: Seq[Inlet[_]] = in :: inTimerContext :: Nil
-  override val outlets: Seq[Outlet[_]] = out :: outTimedResult :: Nil
+  override val inlets: collection.immutable.Seq[Inlet[_]] = in :: inTimerContext :: Nil
+  override val outlets: collection.immutable.Seq[Outlet[_]] = out :: outTimedResult :: Nil
 
   override def deepCopy(): TimerEndShape[InOut] =
     TimerEndShape(in.carbonCopy(), inTimerContext.carbonCopy(), out.carbonCopy(), outTimedResult.carbonCopy())

--- a/src/test/scala/akka/stream/contrib/LatencyTimerSpec.scala
+++ b/src/test/scala/akka/stream/contrib/LatencyTimerSpec.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2016 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.stream.contrib
+
+import java.time.Clock
+import java.time.temporal.ChronoUnit
+
+import akka.actor.ActorSystem
+import akka.stream.contrib.LatencyTimer.TimedResult
+import akka.stream.scaladsl.{Flow, Keep, Sink}
+import akka.stream.testkit.scaladsl.TestSource
+import akka.stream.{ActorAttributes, Supervision}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{GivenWhenThen, OptionValues}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContextExecutor}
+
+import akka.stream.contrib.Implicits._
+
+class LatencyTimerSpec extends AnyFeatureSpec with GivenWhenThen with Matchers with MockFactory with OptionValues {
+
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val executionContext: ExecutionContextExecutor = system.dispatcher
+
+  /**
+   *
+   */
+  Scenario("LatencyTimer measures time correct and continues with the wrapped flow") {
+    val clockMock = mock[Clock]
+    val baseInstant = Clock.systemDefaultZone().instant()
+    var timerResult: FiniteDuration = null
+
+    val TimePassed = 100.millis
+
+    Given(s"a Flow stage that 'waits' for $TimePassed")
+    val testFlow = Flow.fromFunction[String, String] { s =>
+      s"hello $s"
+    }
+    val measuredFlow = LatencyTimer.createGraph(
+      testFlow,
+      Sink.foreach[TimedResult[String]](x => timerResult = x.measuredTime)
+    )(clockMock)
+
+    (clockMock.instant _).expects().returns(baseInstant)
+    (clockMock.instant _).expects().returns(baseInstant.plus(TimePassed.length, ChronoUnit.MILLIS))
+
+    When("running the stream with one element")
+    val (sourceProbe, materializedValue) = TestSource.probe[String].via(measuredFlow).toMat(Sink.head)(Keep.both).run()
+    sourceProbe.sendNext("timer")
+    sourceProbe.sendComplete()
+    Await.result(materializedValue, 1.seconds)
+
+    Then(s"the measured time is $TimePassed")
+    timerResult should equal(TimePassed)
+
+    And("the wrapped flow materializes correct")
+    materializedValue.value.value.get should equal("hello timer")
+  }
+
+  /**
+   *
+   */
+  Scenario("LatencyTimer handles diverting Flows") {
+    val clockMock = mock[Clock]
+    val baseInstant = Clock.systemDefaultZone().instant()
+    var timerResult: FiniteDuration = null
+
+    val TimePassedFirst = 100.millis
+    val TimePassedSecondDiverted = 10.millis
+    val TimePassedThird = 50.millis
+
+    Given("a Integer-Flow that diverts for element == 2")
+    val divertingTestFlow = Flow
+      .fromFunction[Int, Int] { i =>
+        i
+      }
+      .divertTo(Sink.ignore, i => i == 2)
+    val measuredFlow = LatencyTimer.createGraph(
+      divertingTestFlow,
+      Sink.foreach[TimedResult[Int]](x => timerResult = x.measuredTime)
+    )(clockMock)
+
+    // first element
+    (clockMock.instant _).expects().returns(baseInstant)
+    (clockMock.instant _).expects().returns(baseInstant.plus(TimePassedFirst.length, ChronoUnit.MILLIS))
+    // second element
+    (clockMock.instant _)
+      .expects()
+      .returns(baseInstant) // (only started because the stop clock is never called because of diverted element)
+    // third element
+    (clockMock.instant _).expects().returns(baseInstant)
+    (clockMock.instant _).expects().returns(baseInstant.plus(TimePassedThird.length, ChronoUnit.MILLIS))
+
+    When("running the stream with one element, measuring the time")
+    val (sourceProbe, materializedValue) = TestSource.probe[Int].via(measuredFlow).toMat(Sink.last)(Keep.both).run()
+    sourceProbe.sendNext(1)
+    sourceProbe.sendNext(2)
+    sourceProbe.sendNext(3)
+    sourceProbe.sendComplete()
+    Await.result(materializedValue, 1.second)
+
+    Then(s"the measured time is $TimePassedThird, which is the last element sent")
+    timerResult should equal(TimePassedThird)
+
+    And("the wrapped flow materializes correct")
+    materializedValue.value.value.get should equal(3)
+  }
+
+  /**
+   * In the DSL we cannot mock out the Clock instance, hence we test DSL separatly
+   */
+  Scenario("LatencyTimer DSL works as expected") {
+    When("running a stream with a flow-stage called by the DSL")
+    val measuredFlow = Flow
+      .fromFunction[String, String](s => s"hello $s")
+      .measureLatency(Sink.ignore)
+    val (sourceProbe, materializedValue) = TestSource
+      .probe[String]
+      .via(measuredFlow)
+      .toMat(Sink.head)(Keep.both)
+      .run()
+    sourceProbe.sendNext("timer")
+    sourceProbe.sendComplete()
+    Await.result(materializedValue, 1.second)
+
+    Then("the wrapped flow materializes correct")
+    materializedValue.value.value.get should equal("hello timer")
+  }
+
+  Scenario("LatencyTimer handles errors") {
+    val clockMock = mock[Clock]
+    val baseInstant = Clock.systemDefaultZone().instant()
+    var timerResult: FiniteDuration = null
+
+    val TimePassedFirst = 100.millis
+    val TimePassedSecondDiverted = 10.millis
+    val TimePassedThird = 50.millis
+
+    Given("a resume restart policy")
+    val decider: Supervision.Decider = _ => Supervision.Resume
+
+    // first element
+    (clockMock.instant _).expects().returns(baseInstant)
+    (clockMock.instant _).expects().returns(baseInstant.plus(TimePassedFirst.length, ChronoUnit.MILLIS))
+    // second element (only started because the stop clock is never called due to resume)
+    (clockMock.instant _).expects().returns(baseInstant)
+    // third element
+    (clockMock.instant _).expects().returns(baseInstant)
+    (clockMock.instant _).expects().returns(baseInstant.plus(TimePassedThird.length, ChronoUnit.MILLIS))
+
+    When("running a stream that is throwing and error")
+    val flow = Flow.fromFunction[Int, Int](i => if (i == 2) throw new RuntimeException("foobar") else i)
+    val measuredFlow =
+      LatencyTimer.createGraph(flow, Sink.foreach[TimedResult[Int]](x => timerResult = x.measuredTime))(clockMock)
+    val (sourceProbe, materializedValue) = TestSource
+      .probe[Int]
+      .via(measuredFlow)
+      .withAttributes(ActorAttributes.supervisionStrategy(decider))
+      .toMat(Sink.last)(Keep.both)
+      .run()
+    sourceProbe.sendNext(1)
+    sourceProbe.sendNext(2)
+    sourceProbe.sendNext(3)
+    sourceProbe.sendComplete()
+    Await.result(materializedValue, 1.second)
+
+    Then("the wrapped flow materializes correct")
+    materializedValue.value.value.get should equal(3)
+
+    And(s"the measured time is $TimePassedThird, which is the element sent after resuming")
+    timerResult should equal(TimePassedThird)
+  }
+}


### PR DESCRIPTION
LatencyTimer provides a operator which can wrap any Flow-Shape and measure how long each element took.
The operator uses the following shape
I -> O, TimedResult[O] when wrapping a Flow[I,O]

The TimedResult contains the wrapped flows result as well in case further logic is needed. Example would be to distinguish between different metrics based on the result of the wrapped flow.

The operator does only support flows which are preserving the order, so no async should be done inside (only mapAsync).

I could not come up with a better name than LatencyTimer and measureLatency in the DSL. Basically "Timed" would have been better but this is already used by another operator.

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
References:
https://discuss.lightbend.com/t/ideas-on-how-to-implement-a-latency-monitor-which-wraps-a-flow/5714/5
