### PR TITLE
AccumulateWhileUnchanged: stop pull() after onTimer()

### DIFF
--- a/src/test/scala/akka/stream/contrib/AccumulateWhileUnchangedSpec.scala
+++ b/src/test/scala/akka/stream/contrib/AccumulateWhileUnchangedSpec.scala
@@ -77,6 +77,60 @@ class AccumulateWhileUnchangedSpec extends BaseStreamSpec {
         src.sendComplete()
         sink.expectComplete()
       }
+
+      "emit after maxDuration with backpressure" in {
+        val (src, sink) = TestSource
+          .probe[Element]
+          .via(AccumulateWhileUnchanged(_.value, maxDuration = Some(100.millis)))
+          .toMat(TestSink.probe[Seq[Element]])(Keep.both)
+          .run()
+
+        // Pull/Push Ones without backpressure
+        sink.request(1)
+        SampleElements.Ones.foreach(src.sendNext)
+        sink.expectNext(SampleElements.Ones)
+
+        // Make more input data available without downstream demand for it
+        SampleElements.Twos.foreach(src.sendNext)
+        // Wait for longer than maxDuration so the timer expires and Twos are pushed
+        sink.expectNoMsg(200.millis)
+        SampleElements.Threes.foreach(src.sendNext)
+        // Wait for longer than maxDuration so the timer expires.
+        // Threes can't be pushed yet since there is no demand.
+        sink.expectNoMsg(200.millis)
+
+        // Verify all expected messages arrive at sink
+        sink.request(2)
+        sink.expectNext(SampleElements.Twos)
+        sink.expectNext(SampleElements.Threes)
+
+        src.sendComplete()
+        sink.expectComplete()
+      }
+    }
+
+    "used with maxElements and maxDuration" should {
+      "emit without dropping" in {
+        val (src, sink) = TestSource
+          .probe[Element]
+          .via(AccumulateWhileUnchanged(_.value, maxElements = Some(2), maxDuration = Some(500.millis)))
+          .toMat(TestSink.probe[Seq[Element]])(Keep.both)
+          .run()
+
+        SampleElements.Twos.foreach(src.sendNext)
+        sink.request(1)
+        sink.expectNext(SampleElements.Twos)
+
+        SampleElements.Ones.foreach(src.sendNext)
+        sink.request(1)
+        sink.expectNext(SampleElements.Ones.take(2))
+
+        // Complete should return last element of Ones immediately
+        src.sendComplete()
+        sink.request(1)
+        sink.expectNext(Seq(SampleElements.Ones(2)))
+        sink.expectComplete()
+      }
     }
   }
 }


### PR DESCRIPTION
If `onTimer()` is called when `buffer` is not empty, it will `push()`
results but the `pull(in)` request will not be canceled. If additional
upstream elements arrive with a different `nextState` which would cause
`pushResults()` to be called again before the downstream indicates demand
via `onPull()`, then `nextElement` would be dropped.

Avoid pushing again after push() from onTimer() until onPull() is called
again to indicate downstream demand. This avoids dropping elements when
pushResults() is called but `out` is not available.

In case a similar issue occurs again, add a `require()` check which will
throw if nextElement would be discarded.

Note that the use of the `downstreamWaiting` flag is very similar to that of
`TwoBuffer` in the [Custom stream processing - Rate decoupled operators][custom-stream-rate-decoupled] example.

[custom-stream-rate-decoupled]: https://doc.akka.io/docs/akka/2.6.13/stream/stream-customize.html#rate-decoupled-operators