### PR TITLE
Replace hardcoded repo.akka.io/maven references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.3
 
+      - name: Setup global resolver
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: "Code style, tests, documentation"
         run: sbt "scalafmtCheckAll; scalafmtSbtCheck; test; doc"

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ scalaVersion := crossScalaVersions.value.head
 
 val AkkaVersion = "2.6.0"
 
-resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,


### PR DESCRIPTION
- `build.sbt`: remove hardcoded `https://repo.akka.io/maven` resolver
- `.github/workflows/ci.yml`: add `setup_global_resolver@main` step to configure the resolver globally in CI